### PR TITLE
Add support for multiple swing modes

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -39,10 +39,20 @@ climate:
       - "max"
       #- auto
     supported_swing_list:
-      - "off"
-      - "vertical" #up to down
-      # - horizontal # Left to right
-      # - both
+      vertical: # defaults to "off" and "auto"
+        - "auto"
+        - "lowest"
+        - "low"
+        - "middle"
+        - "high"
+        - "highest"
+      # horizontal # defaults to an empty list
+        # - "auto"
+        # - "leftmax"
+        # - "left"
+        # - "middle"
+        # - "right"
+        # - "rightmax"
     default_quiet_mode: "Off" #optional - default "Off" string value
     default_turbo_mode: "Off" #optional - default "Off" string value
     default_econo_mode: "Off" #optional - default "Off" string value

--- a/tasmota_irhvac/climate.py
+++ b/tasmota_irhvac/climate.py
@@ -609,14 +609,14 @@ class TasmotaIrhvac(ClimateDevice, RestoreEntity):
                     self._swing_vertical = payload["SwingV"].lower()
                     if self._swing_vertical != previous_swing:
                         if self._swing_list[SWING_VERTICAL] and self._swing_list[SWING_HORIZONTAL]:
-                            self._swing_vertical = "vertical " + self._swing_vertical
+                            self._swing_vertical = "{} {}".format(SWING_VERTICAL, self._swing_vertical)
                         self._swing_mode = self._swing_vertical
                 if "SwingH" in payload:
                     previous_swing = self._swing_horizontal
                     self._swing_horizontal = payload["SwingH"].lower()
                     if self._swing_horizontal != previous_swing:
                         if self._swing_list[SWING_VERTICAL] and self._swing_list[SWING_HORIZONTAL]:
-                            self._swing_horizontal = "horizontal " + self._swing_horizontal
+                            self._swing_horizontal = "{} {}".format(SWING_HORIZONTAL, self._swing_horizontal)
                         self._swing_mode = self._swing_horizontal
 
                 if "FanSpeed" in payload:
@@ -783,8 +783,8 @@ class TasmotaIrhvac(ClimateDevice, RestoreEntity):
         swing_horizontal = self._swing_list[SWING_HORIZONTAL]
 
         if swing_vertical and swing_horizontal:
-            swing_vertical = ["vertical " + s for s in swing_vertical]
-            swing_horizontal = ["horizontal " + s for s in swing_horizontal]
+            swing_vertical = ["{} {}".format(SWING_VERTICAL, s) for s in swing_vertical]
+            swing_horizontal = ["{} {}".format(SWING_HORIZONTAL, s) for s in swing_horizontal]
         
         swing_list = swing_vertical + swing_horizontal
         return swing_list

--- a/tasmota_irhvac/const.py
+++ b/tasmota_irhvac/const.py
@@ -45,7 +45,7 @@ HVAC_MODE_DRY = "dry"
 # Only the fan is on, not fan and another mode like cool
 HVAC_MODE_FAN_ONLY = "fan_only"
 
-# Hvac moed list
+# Hvac modes list
 HVAC_MODES = [
     HVAC_MODE_OFF,
     HVAC_MODE_HEAT,
@@ -57,6 +57,23 @@ HVAC_MODES = [
     HVAC_MODE_AUTO_FAN,
     HVAC_MODE_FAN_AUTO,
 ]
+
+SWING_VERTICAL_OFF = "off"
+SWING_VERTICAL_AUTO = "auto"
+SWING_VERTICAL_LOWEST = "lowest"
+SWING_VERTICAL_LOW = "low"
+SWING_VERTICAL_MIDDLE = "middle"
+SWING_VERTICAL_HIGH = "high"
+SWING_VERTICAL_HIGHEST = "highest"
+
+SWING_HORIZONTAL_OFF = "off"
+SWING_HORIZONTAL_AUTO = "auto"
+SWING_HORIZONTAL_LEFT_MAX = "leftmax"
+SWING_HORIZONTAL_LEFT = "left"
+SWING_HORIZONTAL_MIDDLE = "middle"
+SWING_HORIZONTAL_RIGHT = "right"
+SWING_HORIZONTAL_RIGHT_MAX = "rightmax"
+SWING_HORIZONTAL_WIDE = "wide"
 
 # Platform specific config entry names
 CONF_PROTOCOL = "protocol"

--- a/tasmota_irhvac/const.py
+++ b/tasmota_irhvac/const.py
@@ -58,6 +58,7 @@ HVAC_MODES = [
     HVAC_MODE_FAN_AUTO,
 ]
 
+# Vertical swing modes
 SWING_VERTICAL_OFF = "off"
 SWING_VERTICAL_AUTO = "auto"
 SWING_VERTICAL_LOWEST = "lowest"
@@ -66,6 +67,7 @@ SWING_VERTICAL_MIDDLE = "middle"
 SWING_VERTICAL_HIGH = "high"
 SWING_VERTICAL_HIGHEST = "highest"
 
+# Horizontal swing modes
 SWING_HORIZONTAL_OFF = "off"
 SWING_HORIZONTAL_AUTO = "auto"
 SWING_HORIZONTAL_LEFT_MAX = "leftmax"


### PR DESCRIPTION
This pull request adds support for multiple swing modes (other than "off" and "auto") for climate entities. It allows for both horizontal and vertical swing configuration.

### Configuration example
```yaml
supported_swing_list:
      vertical: # defaults to "off" and "auto"
        - "auto"
        - "lowest"
        - "low"
        - "middle"
        - "high"
        - "highest"
      horizontal: # defaults to an empty list
        - "auto"
        - "leftmax"
        - "left"
        - "middle"
        - "right"
        - "rightmax"
```

In this case, because vertical and horizontal modes were defined, they will have a prefix added to their names so they become distinguishable (eg "middle" becomes "vertical middle"), since Home Assistant doesn't support two swing mode lists. The integration will then display both mode lists so the user can set each one separately (one at a time).

<img width="142" alt="swing list" src="https://user-images.githubusercontent.com/41346220/81510306-21c6d180-92e7-11ea-9225-77d1c7636741.png">

The "both" and "off" modes were removed since now there's a more detailed configuration. However, I made [another branch](https://github.com/joogps/Tasmota-IRHVAC/tree/mantain-both) that makes the integration automatically create them if both lists have "auto" or "off".

Users that had already defined those parameters will need to reconfigure in order to make the integration finish setup properly.

Updates on `IrReceived` are also working:

![received](https://user-images.githubusercontent.com/41346220/81510031-4a4dcc00-92e5-11ea-8970-e98e1ab05bee.gif)
