### PR TITLE
Allow working with the `stat` which is slightly more stable

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -519,18 +519,19 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity):
             """Handle new MQTT state messages."""
             json_payload = json.loads(msg.payload)
             _LOGGER.debug(json_payload)
-            if "IrReceived" not in json_payload:
-                return
-            if "IRHVAC" not in json_payload["IrReceived"]:
+
+            # If listening to `tele`, result looks like: {"IrReceived":{"Protocol":"XXX", ... ,"IRHVAC":{ ... }}}
+            # we want to extract the data.
+            if "IrReceived" in json_payload:
+                json_payload = json_payload["IrReceived"]
+
+            # By now the payload must include an `IRHVAC` field.
+            if "IRHVAC" not in json_payload:
                 return
 
-            payload = json_payload["IrReceived"]["IRHVAC"]
-            _LOGGER.debug(payload)
-            if (
-                payload["Vendor"] == self._protocol
-                and str(payload["Model"]) == self._model
-            ):
-                _LOGGER.debug("we have a match")
+            payload = json_payload["IRHVAC"]
+
+            if payload["Vendor"].lower() == self._protocol:
                 # All values in the payload are Optional
                 if "Power" in payload:
                     self.power_mode = payload["Power"].lower()
@@ -930,9 +931,8 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity):
 
     def send_ir(self):
         """Send the payload to tasmota mqtt topic."""
-        curr_operation = self._hvac_mode
         fan_speed = self.fan_mode
-        # tweek for some ELECTRA_AC devices
+        # tweak for some ELECTRA_AC devices
         if HVAC_FAN_MAX_HIGH in self._fan_list and HVAC_FAN_AUTO_MAX in self._fan_list:
             if self.fan_mode == FAN_HIGH:
                 fan_speed = HVAC_FAN_MAX
@@ -954,7 +954,7 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity):
             "Vendor": self._protocol,
             "Model": self._model,
             "Power": self.power_mode,
-            "Mode": curr_operation,
+            "Mode": self._hvac_mode,
             "Celsius": self._celsius,
             "Temp": self._target_temp,
             "FanSpeed": fan_speed,

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -1,8 +1,13 @@
 climate:
   - platform: tasmota_irhvac
-    name: "Daewoo IRHvac"
-    command_topic: "cmnd/kitchenMultisensor/irhvac"
-    state_topic: "tele/kitchenMultisensor/RESULT"
+    name: "Some Name Here"
+    command_topic: "cmnd/your_tasmota_device/irhvac"
+    # Pick one of the following:
+    # State is updated when the tasmota device receives an IR signal (includes own transmission and original remote)
+    # useful when a normal remote is in use alongside the tasmota device, may be less reliable than the second option.
+    state_topic: "tele/your_tasmota_device/RESULT"
+    # State is updated when the tasmota device completes IR transmissionm, should be pretty reliable.
+    state_topic: "stat/your_tasmota_device/RESULT"
     temperature_sensor: sensor.kitchen_temperature
     protocol: "ELECTRA_AC"
     min_temp: 16 #optional - default 16 int value
@@ -17,9 +22,9 @@ climate:
       - "dry"
       - "fan_only"
       - "auto"
-      - "off" #Turns the AC off - Should be quoted
-      # Some devices have "auto" and "fan_only" chaned
-      # If following two lines are uncommented, "auto" and "fan" shoud be commented
+      - "off" #Turns the AC off - Should be in quotes
+      # Some devices have "auto" and "fan_only" switched
+      # If the following two lines are uncommented, "auto" and "fan" shoud be commented out
       #- auto_fan_only #if remote shows fan but tasmota says auto
       #- fan_only_auto #if remote shows auto but tasmota says fan
     supported_fan_speeds:


### PR DESCRIPTION
Support working with `stat` topics, since they are updated when the IR command is sent, more stable than `tele` and usefule when not using the remote.

Additionally In tasmota 8.4 `vendor` was uppercase which prevented the parser from working.

Also small cleanup of comments/config yaml.