### PR TITLE
Compare payload vendor to self._vendor

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -541,7 +541,7 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity):
 
             payload = json_payload["IRHVAC"]
 
-            if payload["Vendor"].lower() == self._protocol:
+            if payload["Vendor"].lower() == self._vendor:
                 # All values in the payload are Optional
                 if "Power" in payload:
                     self.power_mode = payload["Power"].lower()


### PR DESCRIPTION
Fixes an error I saw in my logs:  `AttributeError: 'TasmotaIrhvac' object has no attribute '_protocol'`

``````
2020-09-09 21:36:00 ERROR (MainThread) [homeassistant.util.logging] Exception in state_message_received when handling msg on 'tele/irblaster/RESULT': '{"IrReceived":{"Protocol":"DAIKIN216","Bits":216,"Data":"0x0x11DA27F00000000211DA270000002E0030000000000000C0000030","Repeat":0,"IRHVAC":{"Vendor":"DAIKIN216","Model":-1,"Power":"Off","Mode":"Off","Celsius":"On","Temp":23,"FanSpeed":"Low","SwingV":"Off","SwingH":"Off","Quiet":"Off","Turbo":"Off","Econo":"Off","Light":"Off","Filter":"Off","Clean":"Off","Beep":"Off","Sleep":-1}}}'
Traceback (most recent call last):
  File "/home/homeassistant/.homeassistant/custom_components/tasmota_irhvac/climate.py", line 544, in state_message_received
    if payload["Vendor"].lower() == self._protocol:
AttributeError: 'TasmotaIrhvac' object has no attribute '_protocol'
```

You may also wish to add .lower() to self._vendor on line 544 on the comparison - I had to change `DAIKIN216` in my configuration.yaml to `daikin216` to have everything in the UI work correctly.