### PR TITLE
22

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -482,7 +482,6 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity, MqttAvailability):
         self._sleep = sleep.lower()
         self._sub_state = None
         self._state_attrs = {}
-        self._available = False
         self._state_attrs.update(
             {attribute: getattr(self, '_' + attribute)
              for attribute in ATTRIBUTES_IRHVAC}
@@ -639,7 +638,6 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity, MqttAvailability):
                 # Update HA UI and State
                 self.schedule_update_ha_state()
 
-
         self._sub_state = await mqtt.subscription.async_subscribe_topics(
             self.hass,
             self._sub_state,
@@ -771,14 +769,6 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity, MqttAvailability):
         Requires SUPPORT_SWING_MODE.
         """
         return self._swing_list
-    
-    @property
-    def available(self) -> bool:
-        """Return if the device is available."""
-        if not self.hass.data[DATA_MQTT].connected and not self.hass.is_stopping:
-            return False
-        return (self.availability_topic == '') or self._available
-
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set hvac mode."""

--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -233,7 +233,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_BEEP, default=DEFAULT_CONF_BEEP): cv.string,
         vol.Optional(CONF_SLEEP, default=DEFAULT_CONF_SLEEP): cv.string,
     }
-).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
+)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(mqtt.MQTT_BASE_PLATFORM_SCHEMA.schema)
+
 
 IRHVAC_SERVICE_SCHEMA = vol.Schema(
     {vol.Required(ATTR_ENTITY_ID): cv.entity_ids})
@@ -340,6 +343,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     tasmotaIrhvac = TasmotaIrhvac(
         hass,
+        config,
         topic,
         vendor,
         name,
@@ -411,6 +415,7 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity, MqttAvailability):
     def __init__(
         self,
         hass,
+        config,
         topic,
         vendor,
         name,

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -2,6 +2,10 @@ climate:
   - platform: tasmota_irhvac
     name: "Some Name Here"
     command_topic: "cmnd/your_tasmota_device/irhvac"
+    #Use the following config options to configure the availability 
+    availability_topic: "tele/your_tasmota_device/LWT"
+    payload_available: "Online"
+    payload_not_available: "Offline"
     # Pick one of the following:
     # State is updated when the tasmota device receives an IR signal (includes own transmission and original remote)
     # useful when a normal remote is in use alongside the tasmota device, may be less reliable than the second option.


### PR DESCRIPTION
**This is my first pull request on github, so please bear with me in case something is wrong.** 

This pull request is related to https://github.com/hristo-atanasov/Tasmota-IRHVAC/issues/22
I have added support to support for MQTT availability feature, which can be enabled using the following standard config keys.
`availability_topic: "tele/<device_name>/LWT"
payload_available: "Online"
payload_not_available: "Offline"
qos: 2`
or
`availability: 
  topic: "tele/<device_name>/LWT"
  payload_available: "Online"
  payload_not_available: "Offline"
qos: 2`


I have tested the change in my hass instance and it is working as expected. 