### PR TITLE
Fix vendor uppercase scenarios

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -438,7 +438,7 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity):
         """Initialize the thermostat."""
         self.topic = topic
         self.hass = hass
-        self._vendor = vendor
+        self._vendor = vendor.lower()
         self._name = name
         self.sensor_entity_id = sensor_entity_id
         self.state_topic = state_topic


### PR DESCRIPTION
On line `551` the logic is checking if the payload vendor on lowercase matches property, but the property itself is most of the times uppercase.
Example payload:
````
18:30:22 MQT: living-room-air/tele/RESULT = {"IrReceived":{"Protocol":"AMCOR","Bits":64,"Data":"0x0x01412E000032001B","Repeat":0,"IRHVAC":{"Vendor":"AMCOR","Model":-1,"Mode":"Cool","Power":"On","Celsius":"On","Temp":23,"FanSpeed":"Auto","SwingV":"Off","SwingH":"Off","Quiet":"Off","Turbo":"Off","Econo":"Off","Light":"Off","Filter":"Off","Clean":"Off","Beep":"Off","Sleep":-1}}}
````
Vendor is `AMCOR` and the logic failed until on `configuration.yml` I changed the vendor / protocol property to "amcor".

This PR fixes this.

Addressing issue #24