### PR TITLE
Enhanced some options and features

### DIFF
--- a/custom_components/tasmota_irhvac/const.py
+++ b/custom_components/tasmota_irhvac/const.py
@@ -58,8 +58,6 @@ HVAC_MODES = [
     HVAC_MODE_FAN_AUTO,
 ]
 
-CONF_UNIQUE_ID = "unique_id"
-
 # Platform specific config entry names
 CONF_EXCLUSIVE_GROUP_VENDOR = "exclusive_group_vendor"
 CONF_VENDOR = "vendor"
@@ -67,12 +65,15 @@ CONF_PROTOCOL = "protocol"  # Soon to be deprecated
 CONF_COMMAND_TOPIC = "command_topic"
 CONF_STATE_TOPIC = "state_topic"
 CONF_TEMP_SENSOR = "temperature_sensor"
+CONF_HUMIDITY_SENSOR = "humidity_sensor"
+CONF_POWER_SENSOR = "power_sensor"
 CONF_MIN_TEMP = "min_temp"
 CONF_MAX_TEMP = "max_temp"
 CONF_TARGET_TEMP = "target_temp"
 CONF_INITIAL_OPERATION_MODE = "initial_operation_mode"
 CONF_AWAY_TEMP = "away_temp"
 CONF_PRECISION = "precision"
+CONF_TEMP_STEP = "temp_step"
 CONF_MODES_LIST = "supported_modes"
 CONF_FAN_LIST = "supported_fan_speeds"
 CONF_SWING_LIST = "supported_swing_list"
@@ -86,6 +87,9 @@ CONF_FILTER = "default_filter_mode"
 CONF_CLEAN = "default_clean_mode"
 CONF_BEEP = "default_beep_mode"
 CONF_SLEEP = "default_sleep_mode"
+CONF_KEEP_MODE = "keep_mode_when_off"
+CONF_SWINGV = "default_swingv"
+CONF_SWINGH = "default_swingh"
 
 # Platform specific default values
 DEFAULT_NAME = "IR AirConditioner"
@@ -95,7 +99,6 @@ DEFAULT_TARGET_TEMP = 26
 DEFAULT_MIN_TEMP = 16
 DEFAULT_MAX_TEMP = 32
 DEFAULT_PRECISION = 1
-DEFAULT_AWAY_TEMP = 24
 DEFAULT_FAN_LIST = [HVAC_FAN_AUTO_MAX,
                     HVAC_FAN_MAX_HIGH, HVAC_FAN_MEDIUM, HVAC_FAN_MIN]
 DEFAULT_CONF_QUIET = "off"
@@ -108,6 +111,7 @@ DEFAULT_CONF_FILTER = "off"
 DEFAULT_CONF_CLEAN = "off"
 DEFAULT_CONF_BEEP = "off"
 DEFAULT_CONF_SLEEP = "-1"
+DEFAULT_CONF_KEEP_MODE = False
 
 ATTR_NAME = "name"
 ATTR_VALUE = "value"
@@ -123,6 +127,9 @@ ATTR_FILTERS = 'filters'
 ATTR_CLEAN = 'clean'
 ATTR_BEEP = 'beep'
 ATTR_SLEEP = 'sleep'
+ATTR_LAST_ON_MODE = 'last_on_mode'
+ATTR_SWINGV = 'swingv'
+ATTR_SWINGH = 'swingh'
 
 SERVICE_ECONO_MODE = 'set_econo'
 SERVICE_TURBO_MODE = 'set_turbo'
@@ -143,7 +150,9 @@ ATTRIBUTES_IRHVAC = {
     ATTR_CLEAN: 'clean',
     ATTR_BEEP: 'beep',
     ATTR_SLEEP: 'sleep',
-
+    ATTR_LAST_ON_MODE: 'last_on_mode',
+    ATTR_SWINGV: 'swingv',
+    ATTR_SWINGH: 'swingh',
 }
 
 ON_OFF_LIST = [


### PR DESCRIPTION
Create a PR that summarizes some extensions. It may be possible to resolve #17, #21, #22, #29, #45, #47 and #49.

@biGdada, @ayavilevich, @RobinSinghNanda, @bilogic, @riddik14, @angsanley, @rishabmehta7 and @hristo-atanasov, Please cooperate in the verification of this PR.

Download: https://github.com/nao-pon/Tasmota-IRHVAC/archive/refs/heads/various.zip

### Changes

1. Added options

```yaml
humidity_sensor: sensor.kitchen_humidity #optional - humidity sensor
power_sensor: binary_sensor.kitchen_ac_power #optional - power sensor (on/off)
default_swingv: "Off" #optional - default None string value
default_swingh: "Off" #optional - default None string value
```

2. Support MQTT availability feature via "LWT"

3. Supports swingV and swingH (Holds the information obtained from the
IR remote control.)

4. Keep as much as possible the various options (vertical vane, lights,
etc.) when operating with the original IR remote control in HA

5. Device statuses are restored to the original state when HA is
restarted.

6. Supports devices that can set the temperature in 0.5 increments

7. Supports Mitsubishi air conditioner weekly timers and older models of
Panasonic air conditioners.
    However, you need a customized Tasmota farm. You can get it from the
link below.
      - https://github.com/nao-pon/Tasmota/tree/irremote_full_custom
      - http://hypweb.net/tasmota/firmware/ir_jema_bridge.bin.gz
      - http://hypweb.net/tasmota/firmware/ir_jema_bridge_ccs811.bin.gz
        (With CCS811 sensor)