### PR TITLE
Remove unnecessary assignments

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -652,31 +652,30 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity, MqttAvailability):
                     state = self.hass.states.get(self._power_sensor)
                     await self._async_power_sensor_changed(self._power_sensor, None, state)
 
-        if hasattr(mqtt.subscription, 'async_prepare_subscribe_topics'):
-            self._sub_state = mqtt.subscription.async_prepare_subscribe_topics(
-                self.hass,
-                self._sub_state,
-                {
+        topics = {
                     CONF_STATE_TOPIC: {
                         "topic": self.state_topic,
                         "msg_callback": state_message_received,
                         "qos": 1,
                     }
-                },
+                }
+
+        if hasattr(mqtt.subscription, 'async_prepare_subscribe_topics'):
+            # for HA Core >= 2022.3.0
+            self._sub_state = mqtt.subscription.async_prepare_subscribe_topics(
+                self.hass,
+                self._sub_state,
+                topics,
             )
 
             await mqtt.subscription.async_subscribe_topics(self.hass, self._sub_state)
 
+        else:
+            # for HA Core < 2022.3.0
             self._sub_state = await mqtt.subscription.async_subscribe_topics(
                 self.hass,
                 self._sub_state,
-                {
-                    CONF_STATE_TOPIC: {
-                        "topic": self.state_topic,
-                        "msg_callback": state_message_received,
-                        "qos": 1,
-                    }
-                },
+                topics,
             )
 
     async def async_will_remove_from_hass(self):

--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -665,11 +665,8 @@ class TasmotaIrhvac(ClimateEntity, RestoreEntity, MqttAvailability):
                 },
             )
 
-            self._sub_state = await mqtt.subscription.async_subscribe_topics(
-                self.hass,
-                self._sub_state
-            )
-        else:
+            await mqtt.subscription.async_subscribe_topics(self.hass, self._sub_state)
+
             self._sub_state = await mqtt.subscription.async_subscribe_topics(
                 self.hass,
                 self._sub_state,


### PR DESCRIPTION
Probably don't need to assign return of `subscription.async_subscribe_topics`.

https://github.com/home-assistant/core/blob/f3a89de71f6fa693016a41397b051bd48c86f841/homeassistant/components/mqtt/subscription.py#L118-L121