### PR TITLE
Fix #78 Add new option `toggle_list`

### DIFF
--- a/custom_components/tasmota_irhvac/const.py
+++ b/custom_components/tasmota_irhvac/const.py
@@ -90,6 +90,7 @@ CONF_SLEEP = "default_sleep_mode"
 CONF_KEEP_MODE = "keep_mode_when_off"
 CONF_SWINGV = "default_swingv"
 CONF_SWINGH = "default_swingh"
+CONF_TOGGLE_LIST = "toggle_list"
 
 # Platform specific default values
 DEFAULT_NAME = "IR AirConditioner"
@@ -150,7 +151,7 @@ ATTRIBUTES_IRHVAC = {
     ATTR_TURBO: 'turbo',
     ATTR_QUIET: 'quiet',
     ATTR_LIGHT: 'light',
-    ATTR_FILTERS: 'filters',
+    ATTR_FILTERS: 'filter',
     ATTR_CLEAN: 'clean',
     ATTR_BEEP: 'beep',
     ATTR_SLEEP: 'sleep',
@@ -168,4 +169,17 @@ ON_OFF_LIST = [
     'Off',
     'on',
     'off'
+]
+
+TOGGLE_ALL_LIST = [
+    'SwingV',
+    'SwingH',
+    'Quiet',
+    'Turbo',
+    'Econo',
+    'Light',
+    'Filter',
+    'Clean',
+    'Beep',
+    'Sleep',
 ]

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -65,3 +65,16 @@ climate:
     default_swingv: "high" #optional - default "" string value
     default_swingh: "left" #optional - default "" string value 
     keep_mode_when_off: True #optional - default False boolean value : Must be True for MITSUBISHI_AC, ECOCLIM, etc.
+    toggle_list: #optional - default []
+      # The toggled property is a setting that does not retain the On state.
+      # Set this if your AC properties are toggle function.
+      #- Beep
+      #- Clean
+      #- Econo
+      #- Filter
+      #- Light
+      #- Quiet
+      #- Sleep
+      #- SwingH
+      #- SwingV
+      #- Turbo


### PR DESCRIPTION
The toggled property is a setting that does not retain the On state. Set this if your AC properties are toggle function.

toggle_list: #optional - default []
    - Beep
    - Clean
    - Econo
    - Filter
    - Light
    - Quiet
    - Sleep
    - SwingH
    - SwingV
    - Turbo