### PR TITLE
Fix #116 Add `state_mode` option to service command

### DIFF
--- a/custom_components/tasmota_irhvac/const.py
+++ b/custom_components/tasmota_irhvac/const.py
@@ -115,6 +115,7 @@ DEFAULT_CONF_CLEAN = "off"
 DEFAULT_CONF_BEEP = "off"
 DEFAULT_CONF_SLEEP = "-1"
 DEFAULT_CONF_KEEP_MODE = False
+DEFAULT_STATE_MODE = "SendStore"
 
 ATTR_NAME = "name"
 ATTR_VALUE = "value"
@@ -135,6 +136,7 @@ ATTR_SWINGV = 'swingv'
 ATTR_SWINGH = 'swingh'
 ATTR_FIX_SWINGV = 'fix_swingv'
 ATTR_FIX_SWINGH = 'fix_swingh'
+ATTR_STATE_MODE = 'state_mode'
 
 SERVICE_ECONO_MODE = 'set_econo'
 SERVICE_TURBO_MODE = 'set_turbo'
@@ -184,4 +186,9 @@ TOGGLE_ALL_LIST = [
     'Clean',
     'Beep',
     'Sleep',
+]
+
+STATE_MODE_LIST = [
+    'StoreOnly',
+    'SendStore'
 ]

--- a/custom_components/tasmota_irhvac/services.yaml
+++ b/custom_components/tasmota_irhvac/services.yaml
@@ -13,6 +13,15 @@ set_econo:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_turbo:
   description: Sets Turbo mode.
@@ -29,6 +38,15 @@ set_turbo:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_filters:
   description: Sets Filters mode.
@@ -45,6 +63,15 @@ set_filters:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_light:
   target:
@@ -61,6 +88,15 @@ set_light:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_quiet:
   target:
@@ -77,6 +113,15 @@ set_quiet:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_clean:
   target:
@@ -93,6 +138,15 @@ set_clean:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_beep:
   target:
@@ -109,6 +163,15 @@ set_beep:
           options:
             - "off"
             - "on"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_sleep:
   description: Sets Sleep mode.
@@ -120,6 +183,15 @@ set_sleep:
       description: Sets Sleep mode
       example: "0"
       required: true
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_swingv:
   description: Sets vane vertical position.
@@ -140,6 +212,15 @@ set_swingv:
             - "middle"
             - "low"
             - "lowest"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore
 
 set_swingh:
   name: Set swingh
@@ -163,3 +244,12 @@ set_swingh:
             - "right"
             - "right max"
             - "wide"
+    state_mode:
+      description: Sets StateMode in MQTT message. Defailt is "SendStore".
+      example: "StoreOnly"
+      required: false
+      selector:
+        select:
+          options:
+            - StoreOnly
+            - SendStore


### PR DESCRIPTION
Certain devices may update their own state at certain times, breaking the synchronization between the state maintained by Home Assistant and the state of the device.

This new service option allows you to keep Home Assistant and your device state synchronized.