### PR TITLE
Fix fan modes

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -1193,14 +1193,14 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
 
     async def send_ir(self):
         """Send the payload to tasmota mqtt topic."""
-        fan_speed = self.fan_mode
+        fan_speed = self._attr_fan_mode
         # tweak for some ELECTRA_AC devices
         if HVAC_FAN_MAX_HIGH in (self._attr_fan_modes or []) and HVAC_FAN_AUTO_MAX in (
             self._attr_fan_modes or []
         ):
-            if self.fan_mode == FAN_HIGH:
+            if fan_speed == FAN_HIGH:
                 fan_speed = HVAC_FAN_MAX
-            if self.fan_mode == HVAC_FAN_MAX:
+            elif fan_speed == HVAC_FAN_MAX:
                 fan_speed = HVAC_FAN_AUTO
 
         # Set the swing mode - default off

--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -933,24 +933,12 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
         if fan_mode not in (self._attr_fan_modes or []):
-            # tweak for some ELECTRA_AC devices
-            if HVAC_FAN_MAX_HIGH in (
-                self._attr_fan_modes or []
-            ) and HVAC_FAN_AUTO_MAX in (self._attr_fan_modes or []):
-                if fan_mode != FAN_HIGH and fan_mode != HVAC_FAN_MAX:
-                    _LOGGER.error(
-                        "Invalid swing mode selected. Got '%s'. Allowed modes are:",
-                        fan_mode,
-                    )
-                    _LOGGER.error(self._attr_fan_modes)
-                    return
-            else:
-                _LOGGER.error(
-                    "Invalid swing mode selected. Got '%s'. Allowed modes are:",
-                    fan_mode,
-                )
-                _LOGGER.error(self._attr_fan_modes)
-                return
+            _LOGGER.error(
+                "Invalid fan mode selected. Got '%s'. Allowed modes are:",
+                fan_mode,
+            )
+            _LOGGER.error(self._attr_fan_modes)
+            return
         self._attr_fan_mode = fan_mode
         if not self._attr_hvac_mode == HVACMode.OFF:
             self.power_mode = STATE_ON


### PR DESCRIPTION
Fix the ELECTRA_AC workaround that became a no-op in de5a190852e4 (not tested with the real hardware).

Prettify the way how fan modes are displayed in the UI for ACs that use min/medium/max instead of low/medium/high.