### PR TITLE
Fixes a few temperature unit conversion bugs

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -1238,7 +1238,7 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
             "Power": self.power_mode,
             "Mode": self._last_on_mode if self._keep_mode else self._attr_hvac_mode,
             "Celsius": self._celsius,
-            "Temp": self._attr_target_temperature,
+            "Temp": round(self._attr_target_temperature / self._temp_precision) * self._temp_precision,
             "FanSpeed": fan_speed,
             "SwingV": self._swingv,
             "SwingH": self._swingh,

--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -26,6 +26,8 @@ from homeassistant.core import cached_property, callback
 from homeassistant.helpers import event as ha_event
 from homeassistant.helpers.restore_state import RestoreEntity
 
+from homeassistant.util.unit_conversion import TemperatureConverter
+
 from homeassistant.components.climate.const import (
     FAN_AUTO,
     FAN_DIFFUSE,
@@ -615,9 +617,9 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
         if old_state is not None:
             # If we have no initial temperature, restore
             if old_state.attributes.get(ATTR_TEMPERATURE) is not None:
-                self._attr_target_temperature = float(
+                self._attr_target_temperature = TemperatureConverter.convert(float(
                     old_state.attributes[ATTR_TEMPERATURE]
-                )
+                ), self.hass.config.units.temperature_unit, self.temperature_unit)
             if old_state.attributes.get(ATTR_PRESET_MODE) == PRESET_AWAY:
                 self._is_away = True
             if old_state.attributes.get(ATTR_FAN_MODE) is not None:
@@ -1141,7 +1143,7 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
     def _async_update_temp(self, state):
         """Update thermostat with latest state from sensor."""
         try:
-            self._attr_current_temperature = float(state.state)
+            self._attr_current_temperature = TemperatureConverter.convert(float(state.state), state.attributes["unit_of_measurement"], self.temperature_unit)
         except ValueError as ex:
             _LOGGER.debug("Unable to update from sensor: %s", ex)
 


### PR DESCRIPTION
These changes fix a few bugs with unit conversions in an environment where AC units that expect temperature commands in celsius are used with a hass installation that is set to fahrenheit as the primary display unit. Note that I cannot tests these changes exhaustively, but the code is written in such a way that if from- and to-units are the same, conversions will turn into no-ops.