### PR TITLE
fix: initialize target temperature to default and persist it immediately

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -579,7 +579,7 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
         self._attr_preset_mode = None
         self._attr_current_temperature = None
         self._attr_current_humidity = None
-        self._attr_target_temperature = None
+        self._attr_target_temperature = self._def_target_temp
 
         self._support_flags = SUPPORT_FLAGS
         if self._away_temp is not None:
@@ -656,6 +656,7 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
                 "No previously saved target temperature, setting to default value %s",
                 self._attr_target_temperature,
             )
+            self.async_write_ha_state()
 
         if self._attr_hvac_mode is HVACMode.OFF:
             self.power_mode = STATE_OFF


### PR DESCRIPTION
## Problem

When an HVAC device is offline (e.g. AC turned off in winter), the MQTT broker retains an `"Offline"` message on the LWT topic. During HA startup, this message is delivered immediately after MQTT subscriptions are set up — **before** the old entity state is restored from the database.

This creates a race condition in `async_added_to_hass`:

```
await _subscribe_topics()        # retained "Offline" LWT delivered → callback scheduled
old_state = await async_get_last_state()  # event loop yields here → callback runs:
                                          #   _attr_available = False
                                          #   async_schedule_update_ha_state()
                                          #   → state written with temperature = None ❌
# Temperature is then restored/defaulted to 24.0, but never re-persisted
```

On every subsequent HA restart, `async_get_last_state()` returns the "unavailable" state with no `temperature` attribute, so the warning fires again and again:

```
No previously saved target temperature, setting to default value 24.0
```

## Fixes

**Fix 1** — Initialize `_attr_target_temperature` to `_def_target_temp` instead of `None`:

The entity now always starts with a valid temperature value. If the race condition causes the state to be written before old-state restoration, the value is already correct (the configured default) instead of `None`.

**Fix 2** — Call `async_write_ha_state()` after applying the fallback default:

If the fallback is still needed (e.g. old state had temperature `< 1`), the corrected value is immediately persisted to the HA database, so the next restart can restore it correctly.

## Affected scenario

Reproducible when:
- The MQTT device is offline at HA startup (retained `"Offline"` LWT in broker)
- No valid `temperature` attribute exists in the last stored entity state

Commonly observed in winter when AC units are not in use.