### PR TITLE
fix: skip temperature sensor update when state is unknown or unavailable

### DIFF
--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -1155,6 +1155,8 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
     @callback
     def _async_update_temp(self, state):
         """Update thermostat with latest state from sensor."""
+        if state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return
         try:
             self._attr_current_temperature = TemperatureConverter.convert(
                 float(state.state),


### PR DESCRIPTION
## Problem

During HA startup, sensors briefly report `unknown` or `unavailable` before delivering their real value. Calling `float(state.state)` on these strings raises a `ValueError`, producing a spurious error in the logs:

```
Unable to update from sensor: could not convert string to float: 'unknown'
Unable to update from sensor: could not convert string to float: 'unavailable'
```

## Fix

Added the same guard that `_async_update_humidity` already uses — skip the update silently when the sensor state is not yet valid:

```python
if state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
    return
```

Real errors (unexpected `ValueError` or missing `unit_of_measurement`) are still caught and logged at `error` level.