### PR TITLE
Add config flow UI with setup wizard and options flow

### DIFF
--- a/custom_components/tasmota_irhvac/__init__.py
+++ b/custom_components/tasmota_irhvac/__init__.py
@@ -1,1 +1,82 @@
-"""The Tasmota Irhvac climate component."""
+"""The Tasmota IRHVAC integration."""
+
+import asyncio
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DATA_KEY, DOMAIN, PLATFORMS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Tasmota IRHVAC integration."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data.setdefault(DATA_KEY, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Tasmota IRHVAC from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data.setdefault(DATA_KEY, {})
+
+    _register_services(hass)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok
+
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register IRHVAC services (idempotent)."""
+    from .climate import SERVICE_TO_METHOD, IRHVAC_SERVICE_SCHEMA
+
+    if hass.services.has_service(DOMAIN, "set_econo"):
+        return
+
+    async def async_service_handler(service):
+        """Map services to methods on TasmotaIrhvac."""
+        method = SERVICE_TO_METHOD.get(service.service, {})
+        params = {
+            key: value for key, value in service.data.items() if key != ATTR_ENTITY_ID
+        }
+        entity_ids = service.data.get(ATTR_ENTITY_ID)
+        if entity_ids:
+            devices = [
+                device
+                for device in hass.data[DATA_KEY].values()
+                if device.entity_id in entity_ids
+            ]
+        else:
+            devices = hass.data[DATA_KEY].values()
+
+        update_tasks = []
+        for device in devices:
+            if not hasattr(device, method["method"]):
+                continue
+            await getattr(device, method["method"])(**params)
+            update_tasks.append(
+                asyncio.create_task(device.async_update_ha_state(True))
+            )
+
+        if update_tasks:
+            await asyncio.wait(update_tasks)
+
+    for irhvac_service, method_info in SERVICE_TO_METHOD.items():
+        schema = method_info.get("schema", IRHVAC_SERVICE_SCHEMA)
+        hass.services.async_register(
+            DOMAIN, irhvac_service, async_service_handler, schema=schema
+        )

--- a/custom_components/tasmota_irhvac/climate.py
+++ b/custom_components/tasmota_irhvac/climate.py
@@ -8,6 +8,7 @@ import uuid
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
+from homeassistant import config_entries
 from homeassistant.components import mqtt
 
 try:
@@ -106,6 +107,7 @@ from .const import (
     CONF_SLEEP,
     CONF_SPECIAL_MODE,
     CONF_STATE_TOPIC,
+    CONF_STATE_TOPIC_2,
     CONF_SWING_LIST,
     CONF_SWINGH,
     CONF_SWINGV,
@@ -404,62 +406,50 @@ SERVICE_TO_METHOD = {
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the generic thermostat platform."""
-    vendor = config.get(CONF_VENDOR)
-    protocol = config.get(CONF_PROTOCOL)
-    name = config.get(CONF_NAME)
-
-    if DATA_KEY not in hass.data:
-        hass.data[DATA_KEY] = {}
-
-    if vendor is None:
-        if protocol is None:
-            _LOGGER.error('Neither vendor nor protocol provided for "%s"!', name)
-            return
-
-        vendor = protocol
-
-    tasmotaIrhvac = TasmotaIrhvac(
-        hass,
-        vendor,
-        config,
+    """Set up via YAML (deprecated — triggers config entry import)."""
+    _LOGGER.warning(
+        "Configuration of Tasmota IRHVAC via YAML is deprecated. "
+        "Your configuration has been imported. Please remove the YAML "
+        "configuration and restart Home Assistant."
     )
-    uuidstr = uuid.uuid4().hex
-    hass.data[DATA_KEY][uuidstr] = tasmotaIrhvac
-
-    async_add_entities([tasmotaIrhvac])
-
-    async def async_service_handler(service):
-        """Map services to methods on TasmotaIrhvac."""
-        method = SERVICE_TO_METHOD.get(service.service, {})
-        params = {
-            key: value for key, value in service.data.items() if key != ATTR_ENTITY_ID
-        }
-        entity_ids = service.data.get(ATTR_ENTITY_ID)
-        if entity_ids:
-            devices = [
-                device
-                for device in hass.data[DATA_KEY].values()
-                if device.entity_id in entity_ids
-            ]
-        else:
-            devices = hass.data[DATA_KEY].values()
-
-        update_tasks = []
-        for device in devices:
-            if not hasattr(device, method["method"]):
-                continue
-            await getattr(device, method["method"])(**params)
-            update_tasks.append(asyncio.create_task(device.async_update_ha_state(True)))
-
-        if update_tasks:
-            await asyncio.wait(update_tasks)
-
-    for irhvac_service in SERVICE_TO_METHOD:
-        schema = SERVICE_TO_METHOD[irhvac_service].get("schema", IRHVAC_SERVICE_SCHEMA)
-        hass.services.async_register(
-            DOMAIN, irhvac_service, async_service_handler, schema=schema
+    from homeassistant.components.persistent_notification import async_create
+    async_create(
+        hass,
+        "Your Tasmota IRHVAC YAML configuration has been imported into the UI. "
+        "Please remove the `platform: tasmota_irhvac` entry from your "
+        "configuration.yaml and restart Home Assistant.",
+        title="Tasmota IRHVAC YAML Import",
+        notification_id="tasmota_irhvac_yaml_import",
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=dict(config),
         )
+    )
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Tasmota IRHVAC climate from a config entry."""
+    hass.data.setdefault(DATA_KEY, {})
+
+    config = {**entry.data, **entry.options}
+
+    vendor = config.get(CONF_VENDOR)
+    if vendor is None:
+        vendor = config.get(CONF_PROTOCOL)
+    if vendor is None:
+        _LOGGER.error("No vendor configured for %s", entry.title)
+        return False
+
+    entity = TasmotaIrhvac(hass, vendor, config)
+
+    if entity.unique_id is None:
+        entity._attr_unique_id = entry.entry_id
+
+    hass.data[DATA_KEY][entry.entry_id] = entity
+    async_add_entities([entity])
 
 
 class TasmotaIrhvac(RestoreEntity, ClimateEntity):
@@ -485,7 +475,7 @@ class TasmotaIrhvac(RestoreEntity, ClimateEntity):
         self._humidity_sensor = config.get(CONF_HUMIDITY_SENSOR)
         self._power_sensor = config.get(CONF_POWER_SENSOR)
         self.state_topic = config[CONF_STATE_TOPIC]
-        self.state_topic2 = config.get(CONF_STATE_TOPIC + "_2")
+        self.state_topic2 = config.get(CONF_STATE_TOPIC_2) or config.get(CONF_STATE_TOPIC + "_2")
         self._away_temp = config.get(CONF_AWAY_TEMP)
         self._saved_target_temp = config[CONF_TARGET_TEMP] or self._away_temp
         self._temp_precision = config[CONF_PRECISION]

--- a/custom_components/tasmota_irhvac/config_flow.py
+++ b/custom_components/tasmota_irhvac/config_flow.py
@@ -1,0 +1,723 @@
+"""Config flow for Tasmota IRHVAC integration."""
+
+import logging
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_DIFFUSE,
+    FAN_FOCUS,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
+    FAN_MIDDLE,
+    FAN_OFF,
+    FAN_ON,
+    HVACMode,
+    SWING_BOTH,
+    SWING_HORIZONTAL,
+    SWING_OFF,
+    SWING_VERTICAL,
+)
+from homeassistant.config_entries import OptionsFlowWithReload
+from homeassistant.const import (
+    CONF_NAME,
+    PRECISION_HALVES,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+)
+
+from .const import (
+    CONF_AVAILABILITY_TOPIC,
+    CONF_AWAY_TEMP,
+    CONF_BEEP,
+    CONF_CELSIUS,
+    CONF_CLEAN,
+    CONF_COMMAND_TOPIC,
+    CONF_ECONO,
+    CONF_EXCLUSIVE_GROUP_VENDOR,
+    CONF_FAN_LIST,
+    CONF_FILTER,
+    CONF_HUMIDITY_SENSOR,
+    CONF_IGNORE_OFF_TEMP,
+    CONF_INITIAL_OPERATION_MODE,
+    CONF_KEEP_MODE,
+    CONF_LIGHT,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    CONF_MODEL,
+    CONF_MODES_LIST,
+    CONF_MQTT_DELAY,
+    CONF_POWER_SENSOR,
+    CONF_PRECISION,
+    CONF_PROTOCOL,
+    CONF_QUIET,
+    CONF_SLEEP,
+    CONF_SPECIAL_MODE,
+    CONF_STATE_TOPIC,
+    CONF_STATE_TOPIC_2,
+    CONF_SWING_LIST,
+    CONF_SWINGH,
+    CONF_SWINGV,
+    CONF_TARGET_TEMP,
+    CONF_TEMP_SENSOR,
+    CONF_TEMP_STEP,
+    CONF_TOGGLE_LIST,
+    CONF_TURBO,
+    CONF_VENDOR,
+    DEFAULT_COMMAND_TOPIC,
+    DEFAULT_CONF_BEEP,
+    DEFAULT_CONF_CELSIUS,
+    DEFAULT_CONF_CLEAN,
+    DEFAULT_CONF_ECONO,
+    DEFAULT_CONF_FILTER,
+    DEFAULT_CONF_KEEP_MODE,
+    DEFAULT_CONF_LIGHT,
+    DEFAULT_CONF_MODEL,
+    DEFAULT_CONF_QUIET,
+    DEFAULT_CONF_SLEEP,
+    DEFAULT_CONF_TURBO,
+    DEFAULT_IGNORE_OFF_TEMP,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    DEFAULT_MQTT_DELAY,
+    DEFAULT_NAME,
+    DEFAULT_PRECISION,
+    DEFAULT_STATE_TOPIC,
+    DEFAULT_TARGET_TEMP,
+    DOMAIN,
+    HVAC_FAN_AUTO,
+    HVAC_FAN_AUTO_MAX,
+    HVAC_FAN_MAX,
+    HVAC_FAN_MAX_HIGH,
+    HVAC_FAN_MEDIUM,
+    HVAC_FAN_MIN,
+    HVAC_MODE_AUTO_FAN,
+    HVAC_MODE_FAN_AUTO,
+    HVAC_MODES,
+    TOGGLE_ALL_LIST,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Keys stored in entry.data (connection/identity)
+DATA_KEYS = {
+    CONF_NAME,
+    CONF_VENDOR,
+    CONF_COMMAND_TOPIC,
+    CONF_STATE_TOPIC,
+    CONF_STATE_TOPIC_2,
+    CONF_AVAILABILITY_TOPIC,
+}
+
+# All valid fan speed options (high to low, special modes at end)
+ALL_FAN_SPEEDS = [
+    FAN_HIGH, HVAC_FAN_MAX_HIGH, HVAC_FAN_MAX, FAN_MEDIUM,
+    HVAC_FAN_MEDIUM, FAN_MIDDLE, FAN_LOW, HVAC_FAN_MIN,
+    HVAC_FAN_AUTO_MAX, HVAC_FAN_AUTO, FAN_AUTO,
+    FAN_ON, FAN_OFF, FAN_FOCUS, FAN_DIFFUSE,
+]
+
+# Default fan speed list (high to low, special modes at end)
+DEFAULT_FAN_LIST = [HVAC_FAN_MAX_HIGH, HVAC_FAN_MEDIUM, HVAC_FAN_MIN, HVAC_FAN_AUTO_MAX]
+
+# Default modes list
+DEFAULT_MODES_LIST = [
+    HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.DRY,
+    HVACMode.FAN_ONLY, HVACMode.AUTO,
+]
+
+DEFAULT_SWING_LIST = [SWING_OFF, SWING_VERTICAL]
+
+# Keys whose SelectSelector values need coercion from str to float
+_FLOAT_KEYS = (CONF_PRECISION, CONF_TEMP_STEP)
+
+# Reusable selector configs
+_ON_OFF_SELECTOR = SelectSelectorConfig(
+    options=["off", "on"], mode=SelectSelectorMode.DROPDOWN
+)
+
+_PRECISION_SELECTOR = SelectSelector(
+    SelectSelectorConfig(
+        options=[
+            {"value": str(PRECISION_TENTHS), "label": "0.1"},
+            {"value": str(PRECISION_HALVES), "label": "0.5"},
+            {"value": str(PRECISION_WHOLE), "label": "1"},
+        ],
+        mode=SelectSelectorMode.DROPDOWN,
+    )
+)
+
+_TEMP_STEP_SELECTOR = SelectSelector(
+    SelectSelectorConfig(
+        options=[
+            {"value": str(PRECISION_HALVES), "label": "0.5"},
+            {"value": str(PRECISION_WHOLE), "label": "1"},
+        ],
+        mode=SelectSelectorMode.DROPDOWN,
+    )
+)
+
+
+def _coerce_floats(data: dict) -> dict:
+    """Coerce SelectSelector string values to float for numeric keys."""
+    for key in _FLOAT_KEYS:
+        if key in data and isinstance(data[key], str):
+            data[key] = float(data[key])
+    return data
+
+
+def _stringify_for_ui(data: dict) -> dict:
+    """Convert stored float values to strings for SelectSelector suggested values."""
+    out = dict(data)
+    for key in _FLOAT_KEYS:
+        if key in out and not isinstance(out[key], str):
+            out[key] = str(out[key])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Options flow schemas (defined once, populated via add_suggested_values_to_schema)
+# ---------------------------------------------------------------------------
+
+OPTIONS_MQTT_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_MQTT_DELAY): NumberSelector(
+            NumberSelectorConfig(min=0, max=30, step=0.1, mode=NumberSelectorMode.BOX)
+        ),
+    }
+)
+
+OPTIONS_TEMPERATURE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_MIN_TEMP): NumberSelector(
+            NumberSelectorConfig(min=0, max=50, step=1, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Optional(CONF_MAX_TEMP): NumberSelector(
+            NumberSelectorConfig(min=0, max=50, step=1, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Optional(CONF_TARGET_TEMP): NumberSelector(
+            NumberSelectorConfig(min=0, max=50, step=1, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Optional(CONF_PRECISION): _PRECISION_SELECTOR,
+        vol.Optional(CONF_TEMP_STEP): _TEMP_STEP_SELECTOR,
+        vol.Optional(CONF_CELSIUS): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_AWAY_TEMP): NumberSelector(
+            NumberSelectorConfig(min=0, max=50, step=1, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Optional(CONF_IGNORE_OFF_TEMP): BooleanSelector(),
+    }
+)
+
+OPTIONS_MODES_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_MODES_LIST): SelectSelector(
+            SelectSelectorConfig(
+                options=HVAC_MODES, multiple=True, mode=SelectSelectorMode.DROPDOWN
+            )
+        ),
+        vol.Optional(CONF_FAN_LIST): SelectSelector(
+            SelectSelectorConfig(
+                options=ALL_FAN_SPEEDS, multiple=True, mode=SelectSelectorMode.DROPDOWN
+            )
+        ),
+        vol.Optional(CONF_SWING_LIST): SelectSelector(
+            SelectSelectorConfig(
+                options=[SWING_OFF, SWING_VERTICAL, SWING_HORIZONTAL, SWING_BOTH],
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_INITIAL_OPERATION_MODE): SelectSelector(
+            SelectSelectorConfig(
+                options=HVAC_MODES, mode=SelectSelectorMode.DROPDOWN
+            )
+        ),
+        vol.Optional(CONF_KEEP_MODE): BooleanSelector(),
+    }
+)
+
+OPTIONS_DEFAULTS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_QUIET): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_TURBO): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_ECONO): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_MODEL): TextSelector(),
+        vol.Optional(CONF_LIGHT): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_FILTER): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_CLEAN): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_BEEP): SelectSelector(_ON_OFF_SELECTOR),
+        vol.Optional(CONF_SLEEP): TextSelector(),
+        vol.Optional(CONF_SWINGV): SelectSelector(
+            SelectSelectorConfig(
+                options=["off", "auto", "highest", "high", "middle", "low", "lowest"],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_SWINGH): SelectSelector(
+            SelectSelectorConfig(
+                options=["off", "auto", "left max", "left", "middle", "right", "right max", "wide"],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+)
+
+OPTIONS_SENSORS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TEMP_SENSOR): EntitySelector(
+            EntitySelectorConfig(domain="sensor")
+        ),
+        vol.Optional(CONF_HUMIDITY_SENSOR): EntitySelector(
+            EntitySelectorConfig(domain="sensor")
+        ),
+        vol.Optional(CONF_POWER_SENSOR): EntitySelector(
+            EntitySelectorConfig(domain=["binary_sensor", "sensor"])
+        ),
+    }
+)
+
+OPTIONS_ADVANCED_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TOGGLE_LIST): SelectSelector(
+            SelectSelectorConfig(
+                options=TOGGLE_ALL_LIST,
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_SPECIAL_MODE): SelectSelector(
+            SelectSelectorConfig(
+                options=["", "auto", "cool", "dry", "fan_only", "heat", "off"],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Config flow
+# ---------------------------------------------------------------------------
+
+class TasmotaIrhvacConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Tasmota IRHVAC."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize the config flow."""
+        self._user_input = {}
+
+    async def async_step_user(self, user_input=None):
+        """Step 1: Device Setup."""
+        errors = {}
+
+        if user_input is not None:
+            vendor = user_input.get(CONF_VENDOR, "")
+            if not vendor:
+                errors[CONF_VENDOR] = "vendor_required"
+            else:
+                self._user_input.update(user_input)
+                return await self.async_step_climate()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
+                    vol.Required(CONF_VENDOR): TextSelector(),
+                    vol.Required(
+                        CONF_COMMAND_TOPIC, default="cmnd/your_device/irhvac"
+                    ): TextSelector(),
+                    vol.Required(
+                        CONF_STATE_TOPIC, default="tele/your_device/RESULT"
+                    ): TextSelector(),
+                    vol.Optional(CONF_STATE_TOPIC_2): TextSelector(),
+                    vol.Optional(CONF_AVAILABILITY_TOPIC): TextSelector(),
+                    vol.Optional(
+                        CONF_MQTT_DELAY, default=DEFAULT_MQTT_DELAY
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0, max=30, step=0.1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_climate(self, user_input=None):
+        """Step 2: Climate Settings."""
+        if user_input is not None:
+            self._user_input.update(user_input)
+            return await self.async_step_advanced()
+
+        return self.async_show_form(
+            step_id="climate",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0, max=50, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0, max=50, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_TARGET_TEMP, default=DEFAULT_TARGET_TEMP
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0, max=50, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_PRECISION, default=str(DEFAULT_PRECISION)
+                    ): _PRECISION_SELECTOR,
+                    vol.Optional(
+                        CONF_TEMP_STEP, default=str(PRECISION_WHOLE)
+                    ): _TEMP_STEP_SELECTOR,
+                    vol.Optional(
+                        CONF_CELSIUS, default=DEFAULT_CONF_CELSIUS
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(CONF_AWAY_TEMP): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0, max=50, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_IGNORE_OFF_TEMP, default=DEFAULT_IGNORE_OFF_TEMP
+                    ): BooleanSelector(),
+                    vol.Optional(
+                        CONF_MODES_LIST, default=DEFAULT_MODES_LIST
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=HVAC_MODES,
+                            multiple=True,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_FAN_LIST, default=DEFAULT_FAN_LIST
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=ALL_FAN_SPEEDS,
+                            multiple=True,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_SWING_LIST, default=DEFAULT_SWING_LIST
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[SWING_OFF, SWING_VERTICAL, SWING_HORIZONTAL, SWING_BOTH],
+                            multiple=True,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_INITIAL_OPERATION_MODE, default=HVACMode.OFF
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=HVAC_MODES,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_KEEP_MODE, default=DEFAULT_CONF_KEEP_MODE
+                    ): BooleanSelector(),
+                }
+            ),
+        )
+
+    async def async_step_advanced(self, user_input=None):
+        """Step 3: Advanced & Sensors."""
+        if user_input is not None:
+            self._user_input.update(user_input)
+            return await self._create_entry()
+
+        return self.async_show_form(
+            step_id="advanced",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_QUIET, default=DEFAULT_CONF_QUIET
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_TURBO, default=DEFAULT_CONF_TURBO
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_ECONO, default=DEFAULT_CONF_ECONO
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_MODEL, default=DEFAULT_CONF_MODEL
+                    ): TextSelector(),
+                    vol.Optional(
+                        CONF_LIGHT, default=DEFAULT_CONF_LIGHT
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_FILTER, default=DEFAULT_CONF_FILTER
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_CLEAN, default=DEFAULT_CONF_CLEAN
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_BEEP, default=DEFAULT_CONF_BEEP
+                    ): SelectSelector(_ON_OFF_SELECTOR),
+                    vol.Optional(
+                        CONF_SLEEP, default=DEFAULT_CONF_SLEEP
+                    ): TextSelector(),
+                    vol.Optional(CONF_SWINGV): SelectSelector(
+                        SelectSelectorConfig(
+                            options=["off", "auto", "highest", "high", "middle", "low", "lowest"],
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(CONF_SWINGH): SelectSelector(
+                        SelectSelectorConfig(
+                            options=["off", "auto", "left max", "left", "middle", "right", "right max", "wide"],
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_TOGGLE_LIST, default=[]
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=TOGGLE_ALL_LIST,
+                            multiple=True,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_SPECIAL_MODE, default=""
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=["", "auto", "cool", "dry", "fan_only", "heat", "off"],
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(CONF_TEMP_SENSOR): EntitySelector(
+                        EntitySelectorConfig(domain="sensor")
+                    ),
+                    vol.Optional(CONF_HUMIDITY_SENSOR): EntitySelector(
+                        EntitySelectorConfig(domain="sensor")
+                    ),
+                    vol.Optional(CONF_POWER_SENSOR): EntitySelector(
+                        EntitySelectorConfig(domain=["binary_sensor", "sensor"])
+                    ),
+                }
+            ),
+        )
+
+    async def _create_entry(self):
+        """Create the config entry from accumulated user input."""
+        vendor = self._user_input.get(CONF_VENDOR, "")
+        topic = self._user_input.get(CONF_COMMAND_TOPIC, "")
+
+        await self.async_set_unique_id(f"{vendor}_{topic}")
+        self._abort_if_unique_id_configured()
+
+        data = {k: v for k, v in self._user_input.items() if k in DATA_KEYS}
+        options = _coerce_floats(
+            {k: v for k, v in self._user_input.items() if k not in DATA_KEYS}
+        )
+
+        return self.async_create_entry(
+            title=data.get(CONF_NAME, DEFAULT_NAME),
+            data=data,
+            options=options,
+        )
+
+    async def async_step_import(self, import_data):
+        """Handle YAML import."""
+        # Normalize protocol -> vendor
+        if CONF_PROTOCOL in import_data and CONF_VENDOR not in import_data:
+            import_data[CONF_VENDOR] = import_data.pop(CONF_PROTOCOL)
+
+        # Handle the old state_topic + "_2" key
+        old_key = CONF_STATE_TOPIC + "_2"
+        if old_key in import_data and CONF_STATE_TOPIC_2 not in import_data:
+            import_data[CONF_STATE_TOPIC_2] = import_data.pop(old_key)
+
+        vendor = import_data.get(CONF_VENDOR, "")
+        topic = import_data.get(CONF_COMMAND_TOPIC, "")
+        await self.async_set_unique_id(f"{vendor}_{topic}")
+        self._abort_if_unique_id_configured()
+
+        data = {k: v for k, v in import_data.items() if k in DATA_KEYS}
+        options = _coerce_floats(
+            {k: v for k, v in import_data.items() if k not in DATA_KEYS}
+        )
+
+        return self.async_create_entry(
+            title=data.get(CONF_NAME, DEFAULT_NAME),
+            data=data,
+            options=options,
+        )
+
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle reconfiguration of connection/identity settings."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        errors = {}
+
+        if user_input is not None:
+            vendor = user_input.get(CONF_VENDOR, "")
+            if not vendor:
+                errors[CONF_VENDOR] = "vendor_required"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={**entry.data, **user_input},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_NAME): TextSelector(),
+                        vol.Required(CONF_VENDOR): TextSelector(),
+                        vol.Required(CONF_COMMAND_TOPIC): TextSelector(),
+                        vol.Required(CONF_STATE_TOPIC): TextSelector(),
+                        vol.Optional(CONF_STATE_TOPIC_2): TextSelector(),
+                        vol.Optional(CONF_AVAILABILITY_TOPIC): TextSelector(),
+                    }
+                ),
+                entry.data,
+            ),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow handler."""
+        return TasmotaIrhvacOptionsFlow()
+
+
+# ---------------------------------------------------------------------------
+# Options flow
+# ---------------------------------------------------------------------------
+
+class TasmotaIrhvacOptionsFlow(OptionsFlowWithReload):
+    """Handle options flow for Tasmota IRHVAC."""
+
+    async def async_step_init(self, user_input=None):
+        """Show the options menu."""
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=[
+                "mqtt",
+                "temperature",
+                "modes",
+                "defaults",
+                "sensors",
+                "advanced_options",
+            ],
+        )
+
+    async def async_step_mqtt(self, user_input=None):
+        """MQTT options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={**self.config_entry.options, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="mqtt",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_MQTT_SCHEMA, self.config_entry.options
+            ),
+        )
+
+    async def async_step_temperature(self, user_input=None):
+        """Temperature options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data=_coerce_floats({**self.config_entry.options, **user_input})
+            )
+
+        return self.async_show_form(
+            step_id="temperature",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_TEMPERATURE_SCHEMA,
+                _stringify_for_ui(self.config_entry.options),
+            ),
+        )
+
+    async def async_step_modes(self, user_input=None):
+        """Mode options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={**self.config_entry.options, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="modes",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_MODES_SCHEMA, self.config_entry.options
+            ),
+        )
+
+    async def async_step_defaults(self, user_input=None):
+        """Default values options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={**self.config_entry.options, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="defaults",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_DEFAULTS_SCHEMA, self.config_entry.options
+            ),
+        )
+
+    async def async_step_sensors(self, user_input=None):
+        """Sensor entity options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={**self.config_entry.options, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="sensors",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_SENSORS_SCHEMA, self.config_entry.options
+            ),
+        )
+
+    async def async_step_advanced_options(self, user_input=None):
+        """Advanced options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={**self.config_entry.options, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="advanced_options",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_ADVANCED_SCHEMA, self.config_entry.options
+            ),
+        )

--- a/custom_components/tasmota_irhvac/const.py
+++ b/custom_components/tasmota_irhvac/const.py
@@ -103,8 +103,11 @@ DEFAULT_IGNORE_OFF_TEMP = False
 ATTR_NAME = "name"
 ATTR_VALUE = "value"
 
+CONF_STATE_TOPIC_2 = "state_topic_2"
+
 DATA_KEY = "tasmota_irhvac.climate"
 DOMAIN = "tasmota_irhvac"
+PLATFORMS = ["climate"]
 
 ATTR_ECONO = "econo"
 ATTR_TURBO = "turbo"

--- a/custom_components/tasmota_irhvac/manifest.json
+++ b/custom_components/tasmota_irhvac/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "tasmota_irhvac",
   "name": "Tasmota Irhvac",
-  "version": "2024.6.3",
+  "version": "2026.04.03",
+  "config_flow": true,
   "documentation": "https://github.com/hristo-atanasov/Tasmota-IRHVAC",
   "issue_tracker": "https://github.com/hristo-atanasov/Tasmota-IRHVAC/issues",
-  "homeassistant": "2022.5.0",
+  "homeassistant": "2026.1.0",
   "requirements": [],
   "dependencies": [
-    "mqtt",
-    "sensor"
+    "mqtt"
   ],
   "codeowners": [
     "@hristo-atanasov",

--- a/custom_components/tasmota_irhvac/strings.json
+++ b/custom_components/tasmota_irhvac/strings.json
@@ -1,0 +1,179 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Device Setup",
+        "description": "Configure your Tasmota IR air conditioner connection.",
+        "data": {
+          "name": "Name",
+          "vendor": "IR Vendor/Protocol",
+          "command_topic": "MQTT Command Topic",
+          "state_topic": "MQTT State Topic",
+          "state_topic_2": "Secondary State Topic",
+          "availability_topic": "Availability Topic",
+          "mqtt_delay": "MQTT Delay (seconds)"
+        },
+        "data_description": {
+          "vendor": "The IR protocol vendor (e.g., SAMSUNG_AC, ELECTRA_AC, FUJITSU_AC, MITSUBISHI_AC).",
+          "command_topic": "MQTT topic for sending IR commands. Usually cmnd/'{device}'/irhvac.",
+          "state_topic": "Primary MQTT topic for receiving AC state updates. Use tele/'{device}'/RESULT to capture all IR signals (including physical remote).",
+          "state_topic_2": "Optional secondary MQTT state topic. Use stat/'{device}'/RESULT to also capture IR transmission confirmations. Subscribes to both topics if set.",
+          "availability_topic": "MQTT topic for device online/offline status. Leave blank to auto-derive from command topic (tele/'{device}'/LWT).",
+          "mqtt_delay": "Delay in seconds between MQTT commands. Use when operating multiple devices to stagger high-current peaks."
+        }
+      },
+      "climate": {
+        "title": "Climate Settings",
+        "description": "Configure temperature ranges, modes, and fan settings. All fields have sensible defaults.",
+        "data": {
+          "min_temp": "Minimum Temperature (\u00b0C)",
+          "max_temp": "Maximum Temperature (\u00b0C)",
+          "target_temp": "Default Target Temperature (\u00b0C)",
+          "precision": "Temperature Precision",
+          "temp_step": "Temperature Step Size",
+          "celsius_mode": "IR Command Temperature Unit",
+          "away_temp": "Away Temperature (\u00b0C)",
+          "ignore_off_temp": "Ignore Off Temperature",
+          "supported_modes": "Supported HVAC Modes",
+          "supported_fan_speeds": "Supported Fan Speeds",
+          "supported_swing_list": "Supported Swing Modes",
+          "initial_operation_mode": "Initial Operation Mode",
+          "keep_mode_when_off": "Keep Mode When Off"
+        },
+        "data_description": {
+          "celsius_mode": "Temperature unit for IR commands sent to the AC. Most AC units use Celsius internally ('on') even if your HA or remote displays Fahrenheit. Only change to 'off' if your specific AC model requires Fahrenheit IR commands.",
+          "ignore_off_temp": "When the AC is turned off via remote, some devices report the lowest temperature. Enable to keep showing the last target temperature instead.",
+          "keep_mode_when_off": "Keep the last HVAC mode when turning off. Required for MITSUBISHI_AC, ECOCLIM, and similar devices.",
+          "away_temp": "Temperature to use when Away preset is active. Leave blank to disable the Away preset.",
+          "supported_fan_speeds": "Note: auto_max/max_high are for devices where the remote shows max but Tasmota reports high, and auto which is actually max."
+        }
+      },
+      "advanced": {
+        "title": "Advanced Settings & Sensors",
+        "description": "Configure default modes, swing positions, toggle properties, and external sensors.",
+        "data": {
+          "default_quiet_mode": "Default Quiet Mode",
+          "default_turbo_mode": "Default Turbo Mode",
+          "default_econo_mode": "Default Economy Mode",
+          "hvac_model": "HVAC Model",
+          "default_light_mode": "Default Light Mode",
+          "default_filter_mode": "Default Filter Mode",
+          "default_clean_mode": "Default Clean Mode",
+          "default_beep_mode": "Default Beep Mode",
+          "default_sleep_mode": "Default Sleep Mode",
+          "default_swingv": "Default Vertical Swing",
+          "default_swingh": "Default Horizontal Swing",
+          "toggle_list": "Toggle Properties",
+          "special_mode": "Special Mode",
+          "temperature_sensor": "Temperature Sensor",
+          "humidity_sensor": "Humidity Sensor",
+          "power_sensor": "Power Sensor"
+        },
+        "data_description": {
+          "hvac_model": "AC model identifier. Use -1 for auto-detection.",
+          "toggle_list": "Properties that don't retain the On state. Set this if your AC has toggle-only controls (pressing the button toggles between on and off rather than setting a specific state).",
+          "special_mode": "Mode to enter for special functions like automatic cleaning after operation. Leave blank to disable.",
+          "temperature_sensor": "External temperature sensor entity for more accurate room temperature readings.",
+          "humidity_sensor": "External humidity sensor entity.",
+          "power_sensor": "Binary sensor or sensor that indicates whether the AC unit is powered on."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Device",
+        "description": "Update the device connection settings.",
+        "data": {
+          "name": "Name",
+          "vendor": "IR Vendor/Protocol",
+          "command_topic": "MQTT Command Topic",
+          "state_topic": "MQTT State Topic",
+          "state_topic_2": "Secondary State Topic",
+          "availability_topic": "Availability Topic"
+        }
+      }
+    },
+    "error": {
+      "vendor_required": "Vendor is required."
+    },
+    "abort": {
+      "already_configured": "This device is already configured.",
+      "reconfigure_successful": "Device reconfigured successfully."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "menu_options": {
+          "mqtt": "MQTT Settings",
+          "temperature": "Temperature Settings",
+          "modes": "Mode Settings",
+          "defaults": "Default Values",
+          "sensors": "Sensors",
+          "advanced_options": "Advanced Settings"
+        }
+      },
+      "mqtt": {
+        "title": "MQTT Settings",
+        "data": {
+          "mqtt_delay": "MQTT Delay (seconds)"
+        }
+      },
+      "temperature": {
+        "title": "Temperature Settings",
+        "data": {
+          "min_temp": "Minimum Temperature (\u00b0C)",
+          "max_temp": "Maximum Temperature (\u00b0C)",
+          "target_temp": "Default Target Temperature (\u00b0C)",
+          "precision": "Temperature Precision",
+          "temp_step": "Temperature Step Size",
+          "celsius_mode": "IR Command Temperature Unit",
+          "away_temp": "Away Temperature (\u00b0C)",
+          "ignore_off_temp": "Ignore Off Temperature"
+        },
+        "data_description": {
+          "celsius_mode": "Temperature unit for IR commands sent to the AC. Most AC units use Celsius internally ('on') even if your HA or remote displays Fahrenheit."
+        }
+      },
+      "modes": {
+        "title": "Mode Settings",
+        "data": {
+          "supported_modes": "Supported HVAC Modes",
+          "supported_fan_speeds": "Supported Fan Speeds",
+          "supported_swing_list": "Supported Swing Modes",
+          "initial_operation_mode": "Initial Operation Mode",
+          "keep_mode_when_off": "Keep Mode When Off"
+        }
+      },
+      "defaults": {
+        "title": "Default Values",
+        "data": {
+          "default_quiet_mode": "Quiet Mode",
+          "default_turbo_mode": "Turbo Mode",
+          "default_econo_mode": "Economy Mode",
+          "hvac_model": "HVAC Model",
+          "default_light_mode": "Light Mode",
+          "default_filter_mode": "Filter Mode",
+          "default_clean_mode": "Clean Mode",
+          "default_beep_mode": "Beep Mode",
+          "default_sleep_mode": "Sleep Mode",
+          "default_swingv": "Default Vertical Swing",
+          "default_swingh": "Default Horizontal Swing"
+        }
+      },
+      "sensors": {
+        "title": "Sensors",
+        "data": {
+          "temperature_sensor": "Temperature Sensor",
+          "humidity_sensor": "Humidity Sensor",
+          "power_sensor": "Power Sensor"
+        }
+      },
+      "advanced_options": {
+        "title": "Advanced Settings",
+        "data": {
+          "toggle_list": "Toggle Properties",
+          "special_mode": "Special Mode"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/tasmota_irhvac/translations/en.json
+++ b/custom_components/tasmota_irhvac/translations/en.json
@@ -1,0 +1,179 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Device Setup",
+        "description": "Configure your Tasmota IR air conditioner connection.",
+        "data": {
+          "name": "Name",
+          "vendor": "IR Vendor/Protocol",
+          "command_topic": "MQTT Command Topic",
+          "state_topic": "MQTT State Topic",
+          "state_topic_2": "Secondary State Topic",
+          "availability_topic": "Availability Topic",
+          "mqtt_delay": "MQTT Delay (seconds)"
+        },
+        "data_description": {
+          "vendor": "The IR protocol vendor (e.g., SAMSUNG_AC, ELECTRA_AC, FUJITSU_AC, MITSUBISHI_AC).",
+          "command_topic": "MQTT topic for sending IR commands. Usually cmnd/'{device}'/irhvac.",
+          "state_topic": "Primary MQTT topic for receiving AC state updates. Use tele/'{device}'/RESULT to capture all IR signals (including physical remote).",
+          "state_topic_2": "Optional secondary MQTT state topic. Use stat/'{device}'/RESULT to also capture IR transmission confirmations. Subscribes to both topics if set.",
+          "availability_topic": "MQTT topic for device online/offline status. Leave blank to auto-derive from command topic (tele/'{device}'/LWT).",
+          "mqtt_delay": "Delay in seconds between MQTT commands. Use when operating multiple devices to stagger high-current peaks."
+        }
+      },
+      "climate": {
+        "title": "Climate Settings",
+        "description": "Configure temperature ranges, modes, and fan settings. All fields have sensible defaults.",
+        "data": {
+          "min_temp": "Minimum Temperature (\u00b0C)",
+          "max_temp": "Maximum Temperature (\u00b0C)",
+          "target_temp": "Default Target Temperature (\u00b0C)",
+          "precision": "Temperature Precision",
+          "temp_step": "Temperature Step Size",
+          "celsius_mode": "IR Command Temperature Unit",
+          "away_temp": "Away Temperature (\u00b0C)",
+          "ignore_off_temp": "Ignore Off Temperature",
+          "supported_modes": "Supported HVAC Modes",
+          "supported_fan_speeds": "Supported Fan Speeds",
+          "supported_swing_list": "Supported Swing Modes",
+          "initial_operation_mode": "Initial Operation Mode",
+          "keep_mode_when_off": "Keep Mode When Off"
+        },
+        "data_description": {
+          "celsius_mode": "Temperature unit for IR commands sent to the AC. Most AC units use Celsius internally ('on') even if your HA or remote displays Fahrenheit. Only change to 'off' if your specific AC model requires Fahrenheit IR commands.",
+          "ignore_off_temp": "When the AC is turned off via remote, some devices report the lowest temperature. Enable to keep showing the last target temperature instead.",
+          "keep_mode_when_off": "Keep the last HVAC mode when turning off. Required for MITSUBISHI_AC, ECOCLIM, and similar devices.",
+          "away_temp": "Temperature to use when Away preset is active. Leave blank to disable the Away preset.",
+          "supported_fan_speeds": "Note: auto_max/max_high are for devices where the remote shows max but Tasmota reports high, and auto which is actually max."
+        }
+      },
+      "advanced": {
+        "title": "Advanced Settings & Sensors",
+        "description": "Configure default modes, swing positions, toggle properties, and external sensors.",
+        "data": {
+          "default_quiet_mode": "Default Quiet Mode",
+          "default_turbo_mode": "Default Turbo Mode",
+          "default_econo_mode": "Default Economy Mode",
+          "hvac_model": "HVAC Model",
+          "default_light_mode": "Default Light Mode",
+          "default_filter_mode": "Default Filter Mode",
+          "default_clean_mode": "Default Clean Mode",
+          "default_beep_mode": "Default Beep Mode",
+          "default_sleep_mode": "Default Sleep Mode",
+          "default_swingv": "Default Vertical Swing",
+          "default_swingh": "Default Horizontal Swing",
+          "toggle_list": "Toggle Properties",
+          "special_mode": "Special Mode",
+          "temperature_sensor": "Temperature Sensor",
+          "humidity_sensor": "Humidity Sensor",
+          "power_sensor": "Power Sensor"
+        },
+        "data_description": {
+          "hvac_model": "AC model identifier. Use -1 for auto-detection.",
+          "toggle_list": "Properties that don't retain the On state. Set this if your AC has toggle-only controls (pressing the button toggles between on and off rather than setting a specific state).",
+          "special_mode": "Mode to enter for special functions like automatic cleaning after operation. Leave blank to disable.",
+          "temperature_sensor": "External temperature sensor entity for more accurate room temperature readings.",
+          "humidity_sensor": "External humidity sensor entity.",
+          "power_sensor": "Binary sensor or sensor that indicates whether the AC unit is powered on."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Device",
+        "description": "Update the device connection settings.",
+        "data": {
+          "name": "Name",
+          "vendor": "IR Vendor/Protocol",
+          "command_topic": "MQTT Command Topic",
+          "state_topic": "MQTT State Topic",
+          "state_topic_2": "Secondary State Topic",
+          "availability_topic": "Availability Topic"
+        }
+      }
+    },
+    "error": {
+      "vendor_required": "Vendor is required."
+    },
+    "abort": {
+      "already_configured": "This device is already configured.",
+      "reconfigure_successful": "Device reconfigured successfully."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "menu_options": {
+          "mqtt": "MQTT Settings",
+          "temperature": "Temperature Settings",
+          "modes": "Mode Settings",
+          "defaults": "Default Values",
+          "sensors": "Sensors",
+          "advanced_options": "Advanced Settings"
+        }
+      },
+      "mqtt": {
+        "title": "MQTT Settings",
+        "data": {
+          "mqtt_delay": "MQTT Delay (seconds)"
+        }
+      },
+      "temperature": {
+        "title": "Temperature Settings",
+        "data": {
+          "min_temp": "Minimum Temperature (\u00b0C)",
+          "max_temp": "Maximum Temperature (\u00b0C)",
+          "target_temp": "Default Target Temperature (\u00b0C)",
+          "precision": "Temperature Precision",
+          "temp_step": "Temperature Step Size",
+          "celsius_mode": "IR Command Temperature Unit",
+          "away_temp": "Away Temperature (\u00b0C)",
+          "ignore_off_temp": "Ignore Off Temperature"
+        },
+        "data_description": {
+          "celsius_mode": "Temperature unit for IR commands sent to the AC. Most AC units use Celsius internally ('on') even if your HA or remote displays Fahrenheit."
+        }
+      },
+      "modes": {
+        "title": "Mode Settings",
+        "data": {
+          "supported_modes": "Supported HVAC Modes",
+          "supported_fan_speeds": "Supported Fan Speeds",
+          "supported_swing_list": "Supported Swing Modes",
+          "initial_operation_mode": "Initial Operation Mode",
+          "keep_mode_when_off": "Keep Mode When Off"
+        }
+      },
+      "defaults": {
+        "title": "Default Values",
+        "data": {
+          "default_quiet_mode": "Quiet Mode",
+          "default_turbo_mode": "Turbo Mode",
+          "default_econo_mode": "Economy Mode",
+          "hvac_model": "HVAC Model",
+          "default_light_mode": "Light Mode",
+          "default_filter_mode": "Filter Mode",
+          "default_clean_mode": "Clean Mode",
+          "default_beep_mode": "Beep Mode",
+          "default_sleep_mode": "Sleep Mode",
+          "default_swingv": "Default Vertical Swing",
+          "default_swingh": "Default Horizontal Swing"
+        }
+      },
+      "sensors": {
+        "title": "Sensors",
+        "data": {
+          "temperature_sensor": "Temperature Sensor",
+          "humidity_sensor": "Humidity Sensor",
+          "power_sensor": "Power Sensor"
+        }
+      },
+      "advanced_options": {
+        "title": "Advanced Settings",
+        "data": {
+          "toggle_list": "Toggle Properties",
+          "special_mode": "Special Mode"
+        }
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+log_format = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+log_date_format = "%H:%M:%S"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Tasmota IRHVAC integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,180 @@
+"""Shared fixtures and helpers for Tasmota IRHVAC tests."""
+
+import json
+
+import pytest
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    HVACMode,
+    SWING_OFF,
+    SWING_VERTICAL,
+)
+from homeassistant.const import CONF_NAME, PRECISION_WHOLE
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.tasmota_irhvac.const import (
+    CONF_AVAILABILITY_TOPIC,
+    CONF_AWAY_TEMP,
+    CONF_BEEP,
+    CONF_CELSIUS,
+    CONF_CLEAN,
+    CONF_COMMAND_TOPIC,
+    CONF_ECONO,
+    CONF_FAN_LIST,
+    CONF_FILTER,
+    CONF_IGNORE_OFF_TEMP,
+    CONF_INITIAL_OPERATION_MODE,
+    CONF_KEEP_MODE,
+    CONF_LIGHT,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    CONF_MODEL,
+    CONF_MODES_LIST,
+    CONF_MQTT_DELAY,
+    CONF_POWER_SENSOR,
+    CONF_PRECISION,
+    CONF_QUIET,
+    CONF_SLEEP,
+    CONF_SPECIAL_MODE,
+    CONF_STATE_TOPIC,
+    CONF_STATE_TOPIC_2,
+    CONF_SWING_LIST,
+    CONF_TARGET_TEMP,
+    CONF_TEMP_SENSOR,
+    CONF_TEMP_STEP,
+    CONF_TOGGLE_LIST,
+    CONF_TURBO,
+    CONF_VENDOR,
+    DATA_KEY,
+    DOMAIN,
+    HVAC_FAN_AUTO_MAX,
+    HVAC_FAN_MAX_HIGH,
+    HVAC_FAN_MEDIUM,
+    HVAC_FAN_MIN,
+)
+
+# ---------------------------------------------------------------------------
+# Default config builder
+# ---------------------------------------------------------------------------
+
+# Keys stored in entry.data (connection/identity)
+_DATA_DEFAULTS = {
+    CONF_NAME: "Test AC",
+    CONF_VENDOR: "SAMSUNG_AC",
+    CONF_COMMAND_TOPIC: "cmnd/tasmota_ac/irhvac",
+    CONF_STATE_TOPIC: "tele/tasmota_ac/RESULT",
+}
+
+# Keys stored in entry.options (everything else)
+_OPTIONS_DEFAULTS = {
+    CONF_MQTT_DELAY: 0,
+    CONF_MIN_TEMP: 16,
+    CONF_MAX_TEMP: 32,
+    CONF_TARGET_TEMP: 26,
+    CONF_PRECISION: PRECISION_WHOLE,
+    CONF_TEMP_STEP: PRECISION_WHOLE,
+    CONF_CELSIUS: "on",
+    CONF_IGNORE_OFF_TEMP: False,
+    CONF_MODES_LIST: [
+        HVACMode.OFF,
+        HVACMode.HEAT,
+        HVACMode.COOL,
+        HVACMode.DRY,
+        HVACMode.FAN_ONLY,
+        HVACMode.AUTO,
+    ],
+    CONF_FAN_LIST: [HVAC_FAN_AUTO_MAX, HVAC_FAN_MAX_HIGH, HVAC_FAN_MEDIUM, HVAC_FAN_MIN],
+    CONF_SWING_LIST: [SWING_OFF, SWING_VERTICAL],
+    CONF_INITIAL_OPERATION_MODE: HVACMode.OFF,
+    CONF_KEEP_MODE: False,
+    CONF_QUIET: "off",
+    CONF_TURBO: "off",
+    CONF_ECONO: "off",
+    CONF_MODEL: "-1",
+    CONF_LIGHT: "off",
+    CONF_FILTER: "off",
+    CONF_CLEAN: "off",
+    CONF_BEEP: "off",
+    CONF_SLEEP: "-1",
+    CONF_TOGGLE_LIST: [],
+    CONF_SPECIAL_MODE: "",
+}
+
+
+def make_config(overrides=None):
+    """Build a full {data, options} dict pair with sensible defaults.
+
+    Returns (data_dict, options_dict).  Pass overrides to replace any key
+    in either dict.
+    """
+    data = dict(_DATA_DEFAULTS)
+    options = dict(_OPTIONS_DEFAULTS)
+    if overrides:
+        for key, val in overrides.items():
+            if key in _DATA_DEFAULTS:
+                data[key] = val
+            else:
+                options[key] = val
+    return data, options
+
+
+def make_mqtt_state_payload(overrides=None):
+    """Build a JSON MQTT state payload (the IRHVAC sub-object Tasmota sends).
+
+    The outer envelope mirrors ``tele/.../RESULT`` format.
+    """
+    irhvac = {
+        "Vendor": "SAMSUNG_AC",
+        "Model": "-1",
+        "Mode": "cool",
+        "Power": "on",
+        "Celsius": "on",
+        "Temp": 24,
+        "FanSpeed": "auto",
+        "SwingV": "off",
+        "SwingH": "off",
+        "Quiet": "off",
+        "Turbo": "off",
+        "Econo": "off",
+        "Light": "off",
+        "Filter": "off",
+        "Clean": "off",
+        "Beep": "off",
+        "Sleep": "-1",
+    }
+    if overrides:
+        irhvac.update(overrides)
+    return json.dumps({"IRHVAC": irhvac})
+
+
+def make_config_entry(data=None, options=None):
+    """Create a MockConfigEntry ready for hass."""
+    if data is None or options is None:
+        d, o = make_config()
+        data = data or d
+        options = options or o
+    return MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        minor_version=1,
+        data=data,
+        options=options,
+        title=data.get(CONF_NAME, "Test AC"),
+        unique_id=f"{data[CONF_VENDOR]}_{data[CONF_COMMAND_TOPIC]}",
+    )
+
+
+async def setup_integration(hass: HomeAssistant, entry=None):
+    """Set up the integration with a MockConfigEntry and return the entry."""
+    if entry is None:
+        entry = make_config_entry()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+def get_climate_entity(hass: HomeAssistant, entry):
+    """Return the climate entity stored for the given config entry."""
+    return hass.data[DATA_KEY].get(entry.entry_id)

--- a/tests/test_climate_mqtt.py
+++ b/tests/test_climate_mqtt.py
@@ -1,0 +1,204 @@
+"""Tests for MQTT state handling in the Tasmota IRHVAC climate entity."""
+
+import json
+
+import pytest
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
+
+from custom_components.tasmota_irhvac.const import DATA_KEY
+
+from tests.conftest import (
+    get_climate_entity,
+    make_mqtt_state_payload,
+    setup_integration,
+)
+
+
+async def test_mqtt_state_updates_mode(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """MQTT payload updates the HVAC mode."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+    assert entity is not None
+
+    # Entity starts in OFF mode
+    assert entity.hvac_mode == HVACMode.OFF
+
+    # Fire an MQTT message that sets the mode to "cool" with power "on"
+    payload = make_mqtt_state_payload({"Mode": "cool", "Power": "on", "Vendor": "SAMSUNG_AC"})
+    async_fire_mqtt_message(hass, "tele/tasmota_ac/RESULT", payload)
+    await hass.async_block_till_done()
+
+    assert entity.hvac_mode == HVACMode.COOL
+
+
+async def test_mqtt_state_updates_temperature(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """MQTT payload updates the target temperature."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    payload = make_mqtt_state_payload({"Temp": 22, "Power": "on", "Mode": "heat", "Vendor": "SAMSUNG_AC"})
+    async_fire_mqtt_message(hass, "tele/tasmota_ac/RESULT", payload)
+    await hass.async_block_till_done()
+
+    assert entity.target_temperature == 22
+
+
+async def test_mqtt_state_updates_fan(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """MQTT payload updates the fan mode."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    payload = make_mqtt_state_payload({"FanSpeed": "min", "Power": "on", "Mode": "cool", "Vendor": "SAMSUNG_AC"})
+    async_fire_mqtt_message(hass, "tele/tasmota_ac/RESULT", payload)
+    await hass.async_block_till_done()
+
+    assert entity.fan_mode == "min"
+
+
+async def test_mqtt_ignores_wrong_vendor(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """MQTT payload from a different vendor is ignored."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    original_temp = entity.target_temperature
+
+    payload = make_mqtt_state_payload({"Vendor": "DAIKIN", "Temp": 18, "Power": "on", "Mode": "cool"})
+    async_fire_mqtt_message(hass, "tele/tasmota_ac/RESULT", payload)
+    await hass.async_block_till_done()
+
+    # Temperature should not have changed
+    assert entity.target_temperature == original_temp
+
+
+async def test_mqtt_nested_ir_received(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """MQTT payload wrapped in IrReceived envelope is correctly parsed."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    irhvac = {
+        "Vendor": "SAMSUNG_AC",
+        "Model": "-1",
+        "Mode": "heat",
+        "Power": "on",
+        "Celsius": "on",
+        "Temp": 28,
+        "FanSpeed": "auto",
+        "SwingV": "off",
+        "SwingH": "off",
+        "Quiet": "off",
+        "Turbo": "off",
+        "Econo": "off",
+        "Light": "off",
+        "Filter": "off",
+        "Clean": "off",
+        "Beep": "off",
+        "Sleep": "-1",
+    }
+    payload = json.dumps({"IrReceived": {"Protocol": "SAMSUNG_AC", "IRHVAC": irhvac}})
+    async_fire_mqtt_message(hass, "tele/tasmota_ac/RESULT", payload)
+    await hass.async_block_till_done()
+
+    assert entity.hvac_mode == HVACMode.HEAT
+    assert entity.target_temperature == 28
+
+
+async def test_send_ir_publishes_mqtt(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Calling send_ir publishes a JSON payload to the command topic."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    # Set mode so send_ir has something to send
+    entity._attr_hvac_mode = HVACMode.COOL
+    entity.power_mode = "on"
+    entity._last_on_mode = HVACMode.COOL
+    entity._attr_target_temperature = 24
+
+    await entity.send_ir()
+    await hass.async_block_till_done()
+
+    # Check that mqtt.async_publish was called on the command topic
+    assert mqtt_mock.async_publish.called
+    call_args = mqtt_mock.async_publish.call_args
+    topic = call_args[0][0]
+    payload_str = call_args[0][1]
+
+    assert topic == "cmnd/tasmota_ac/irhvac"
+    payload_data = json.loads(payload_str)
+    assert payload_data["Vendor"] == "SAMSUNG_AC"
+    assert payload_data["Mode"] == HVACMode.COOL
+    assert payload_data["Temp"] == 24
+    assert payload_data["Power"] == "on"
+
+
+async def test_availability_message(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Availability topic updates entity availability."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    # Default availability topic is derived: tele/<device>/LWT
+    # For command topic "cmnd/tasmota_ac/irhvac", device is "tasmota_ac"
+    avail_topic = "tele/tasmota_ac/LWT"
+
+    # Online message
+    async_fire_mqtt_message(hass, avail_topic, "Online")
+    await hass.async_block_till_done()
+    assert entity.available is True
+
+    # Offline message
+    async_fire_mqtt_message(hass, avail_topic, "Offline")
+    await hass.async_block_till_done()
+    assert entity.available is False
+
+    # Back online
+    async_fire_mqtt_message(hass, avail_topic, "Online")
+    await hass.async_block_till_done()
+    assert entity.available is True
+
+
+async def test_mqtt_invalid_json_ignored(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Invalid JSON on the state topic does not crash the entity."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    original_mode = entity.hvac_mode
+
+    async_fire_mqtt_message(hass, "tele/tasmota_ac/RESULT", "not valid json{{{")
+    await hass.async_block_till_done()
+
+    # Entity state unchanged
+    assert entity.hvac_mode == original_mode
+
+
+async def test_mqtt_payload_without_irhvac_ignored(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """MQTT JSON without an IRHVAC key is silently ignored."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+
+    original_temp = entity.target_temperature
+
+    async_fire_mqtt_message(
+        hass, "tele/tasmota_ac/RESULT", json.dumps({"StatusSNS": {"Time": "2024-01-01"}})
+    )
+    await hass.async_block_till_done()
+
+    assert entity.target_temperature == original_temp

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,469 @@
+"""Tests for the Tasmota IRHVAC config flow (3-step wizard, import, reconfigure)."""
+
+import pytest
+from homeassistant.components.climate.const import HVACMode, SWING_OFF, SWING_VERTICAL
+from homeassistant.const import CONF_NAME, PRECISION_HALVES, PRECISION_WHOLE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.tasmota_irhvac.const import (
+    CONF_AVAILABILITY_TOPIC,
+    CONF_BEEP,
+    CONF_CELSIUS,
+    CONF_CLEAN,
+    CONF_COMMAND_TOPIC,
+    CONF_ECONO,
+    CONF_FAN_LIST,
+    CONF_FILTER,
+    CONF_IGNORE_OFF_TEMP,
+    CONF_INITIAL_OPERATION_MODE,
+    CONF_KEEP_MODE,
+    CONF_LIGHT,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    CONF_MODEL,
+    CONF_MODES_LIST,
+    CONF_MQTT_DELAY,
+    CONF_PRECISION,
+    CONF_PROTOCOL,
+    CONF_QUIET,
+    CONF_SLEEP,
+    CONF_SPECIAL_MODE,
+    CONF_STATE_TOPIC,
+    CONF_STATE_TOPIC_2,
+    CONF_SWING_LIST,
+    CONF_TARGET_TEMP,
+    CONF_TEMP_STEP,
+    CONF_TOGGLE_LIST,
+    CONF_TURBO,
+    CONF_VENDOR,
+    DOMAIN,
+    HVAC_FAN_AUTO_MAX,
+    HVAC_FAN_MAX_HIGH,
+    HVAC_FAN_MEDIUM,
+    HVAC_FAN_MIN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Wizard step data
+# ---------------------------------------------------------------------------
+
+STEP1_INPUT = {
+    CONF_NAME: "Living Room AC",
+    CONF_VENDOR: "SAMSUNG_AC",
+    CONF_COMMAND_TOPIC: "cmnd/ir_ac/irhvac",
+    CONF_STATE_TOPIC: "tele/ir_ac/RESULT",
+    CONF_MQTT_DELAY: 0,
+}
+
+STEP2_INPUT = {
+    CONF_MIN_TEMP: 16,
+    CONF_MAX_TEMP: 32,
+    CONF_TARGET_TEMP: 24,
+    CONF_PRECISION: str(PRECISION_WHOLE),
+    CONF_TEMP_STEP: str(PRECISION_WHOLE),
+    CONF_CELSIUS: "on",
+    CONF_IGNORE_OFF_TEMP: False,
+    CONF_MODES_LIST: [
+        HVACMode.OFF,
+        HVACMode.HEAT,
+        HVACMode.COOL,
+        HVACMode.DRY,
+        HVACMode.FAN_ONLY,
+        HVACMode.AUTO,
+    ],
+    CONF_FAN_LIST: [HVAC_FAN_AUTO_MAX, HVAC_FAN_MAX_HIGH, HVAC_FAN_MEDIUM, HVAC_FAN_MIN],
+    CONF_SWING_LIST: [SWING_OFF, SWING_VERTICAL],
+    CONF_INITIAL_OPERATION_MODE: HVACMode.OFF,
+    CONF_KEEP_MODE: False,
+}
+
+STEP3_INPUT = {
+    CONF_QUIET: "off",
+    CONF_TURBO: "off",
+    CONF_ECONO: "off",
+    CONF_MODEL: "-1",
+    CONF_LIGHT: "off",
+    CONF_FILTER: "off",
+    CONF_CLEAN: "off",
+    CONF_BEEP: "off",
+    CONF_SLEEP: "-1",
+    CONF_TOGGLE_LIST: [],
+    CONF_SPECIAL_MODE: "",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_user_step_shows_form(hass: HomeAssistant, enable_custom_integrations):
+    """Step 1 of the wizard renders a form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_full_wizard_creates_entry(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Completing all three wizard steps creates a config entry."""
+    # Step 1
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP1_INPUT
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "climate"
+
+    # Step 2
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "advanced"
+
+    # Step 3
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP3_INPUT
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Living Room AC"
+
+    # Connection keys live in data
+    assert result["data"][CONF_VENDOR] == "SAMSUNG_AC"
+    assert result["data"][CONF_COMMAND_TOPIC] == "cmnd/ir_ac/irhvac"
+    assert result["data"][CONF_STATE_TOPIC] == "tele/ir_ac/RESULT"
+    assert result["data"][CONF_NAME] == "Living Room AC"
+
+    # Everything else lives in options
+    assert result["options"][CONF_MIN_TEMP] == 16
+    assert result["options"][CONF_MAX_TEMP] == 32
+    assert result["options"][CONF_TARGET_TEMP] == 24
+    assert result["options"][CONF_QUIET] == "off"
+
+
+async def test_vendor_required(hass: HomeAssistant, enable_custom_integrations):
+    """Step 1 rejects an empty vendor with an error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test",
+            CONF_VENDOR: "",
+            CONF_COMMAND_TOPIC: "cmnd/test/irhvac",
+            CONF_STATE_TOPIC: "tele/test/RESULT",
+            CONF_MQTT_DELAY: 0,
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"][CONF_VENDOR] == "vendor_required"
+
+
+async def test_duplicate_entry_aborted(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """A second entry with the same vendor+topic is aborted."""
+    # Create first entry via the wizard
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP1_INPUT
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP3_INPUT
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    # Try again with identical step 1 data
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], STEP1_INPUT
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], STEP2_INPUT
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"], STEP3_INPUT
+    )
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_import_from_yaml(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """YAML import creates a config entry with correct data/options split."""
+    yaml_config = {
+        CONF_NAME: "Imported AC",
+        CONF_VENDOR: "DAIKIN",
+        CONF_COMMAND_TOPIC: "cmnd/daikin/irhvac",
+        CONF_STATE_TOPIC: "tele/daikin/RESULT",
+        CONF_MQTT_DELAY: 0.5,
+        CONF_MIN_TEMP: 18,
+        CONF_MAX_TEMP: 30,
+        CONF_TARGET_TEMP: 22,
+        CONF_PRECISION: PRECISION_WHOLE,
+        CONF_TEMP_STEP: PRECISION_WHOLE,
+        CONF_CELSIUS: "on",
+        CONF_IGNORE_OFF_TEMP: False,
+        CONF_MODES_LIST: [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT],
+        CONF_FAN_LIST: [HVAC_FAN_AUTO_MAX, HVAC_FAN_MIN],
+        CONF_SWING_LIST: [SWING_OFF],
+        CONF_INITIAL_OPERATION_MODE: HVACMode.OFF,
+        CONF_KEEP_MODE: False,
+        CONF_QUIET: "off",
+        CONF_TURBO: "off",
+        CONF_ECONO: "off",
+        CONF_MODEL: "-1",
+        CONF_LIGHT: "off",
+        CONF_FILTER: "off",
+        CONF_CLEAN: "off",
+        CONF_BEEP: "off",
+        CONF_SLEEP: "-1",
+        CONF_TOGGLE_LIST: [],
+        CONF_SPECIAL_MODE: "",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data=yaml_config
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Imported AC"
+    assert result["data"][CONF_VENDOR] == "DAIKIN"
+    assert result["data"][CONF_COMMAND_TOPIC] == "cmnd/daikin/irhvac"
+    # Options
+    assert result["options"][CONF_MQTT_DELAY] == 0.5
+    assert result["options"][CONF_MIN_TEMP] == 18
+
+
+async def test_import_duplicate_aborted(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """YAML import with an existing entry (same vendor+topic) aborts."""
+    yaml_config = {
+        CONF_NAME: "AC",
+        CONF_VENDOR: "LG",
+        CONF_COMMAND_TOPIC: "cmnd/lg/irhvac",
+        CONF_STATE_TOPIC: "tele/lg/RESULT",
+        CONF_MQTT_DELAY: 0,
+        CONF_MIN_TEMP: 16,
+        CONF_MAX_TEMP: 32,
+        CONF_TARGET_TEMP: 26,
+        CONF_PRECISION: PRECISION_WHOLE,
+        CONF_TEMP_STEP: PRECISION_WHOLE,
+        CONF_CELSIUS: "on",
+        CONF_QUIET: "off",
+        CONF_TURBO: "off",
+        CONF_ECONO: "off",
+        CONF_MODEL: "-1",
+        CONF_LIGHT: "off",
+        CONF_FILTER: "off",
+        CONF_CLEAN: "off",
+        CONF_BEEP: "off",
+        CONF_SLEEP: "-1",
+        CONF_KEEP_MODE: False,
+        CONF_IGNORE_OFF_TEMP: False,
+        CONF_MODES_LIST: [HVACMode.OFF, HVACMode.COOL],
+        CONF_FAN_LIST: [HVAC_FAN_MIN],
+        CONF_SWING_LIST: [SWING_OFF],
+        CONF_INITIAL_OPERATION_MODE: HVACMode.OFF,
+        CONF_TOGGLE_LIST: [],
+        CONF_SPECIAL_MODE: "",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data=dict(yaml_config)
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data=dict(yaml_config)
+    )
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_import_normalizes_protocol_to_vendor(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Old 'protocol' key is mapped to 'vendor' during import."""
+    yaml_config = {
+        CONF_NAME: "Old Config",
+        CONF_PROTOCOL: "MITSUBISHI_AC",
+        CONF_COMMAND_TOPIC: "cmnd/old/irhvac",
+        CONF_STATE_TOPIC: "tele/old/RESULT",
+        CONF_MQTT_DELAY: 0,
+        CONF_MIN_TEMP: 16,
+        CONF_MAX_TEMP: 32,
+        CONF_TARGET_TEMP: 26,
+        CONF_PRECISION: PRECISION_WHOLE,
+        CONF_TEMP_STEP: PRECISION_WHOLE,
+        CONF_CELSIUS: "on",
+        CONF_QUIET: "off",
+        CONF_TURBO: "off",
+        CONF_ECONO: "off",
+        CONF_MODEL: "-1",
+        CONF_LIGHT: "off",
+        CONF_FILTER: "off",
+        CONF_CLEAN: "off",
+        CONF_BEEP: "off",
+        CONF_SLEEP: "-1",
+        CONF_KEEP_MODE: False,
+        CONF_IGNORE_OFF_TEMP: False,
+        CONF_MODES_LIST: [HVACMode.OFF, HVACMode.COOL],
+        CONF_FAN_LIST: [HVAC_FAN_MIN],
+        CONF_SWING_LIST: [SWING_OFF],
+        CONF_INITIAL_OPERATION_MODE: HVACMode.OFF,
+        CONF_TOGGLE_LIST: [],
+        CONF_SPECIAL_MODE: "",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data=yaml_config
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_VENDOR] == "MITSUBISHI_AC"
+    # protocol should NOT be in data (it was consumed)
+    assert CONF_PROTOCOL not in result["data"]
+
+
+async def test_import_handles_state_topic_2(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Old 'state_topic_2' key format is preserved during import."""
+    yaml_config = {
+        CONF_NAME: "Dual Topic",
+        CONF_VENDOR: "SAMSUNG_AC",
+        CONF_COMMAND_TOPIC: "cmnd/dual/irhvac",
+        CONF_STATE_TOPIC: "tele/dual/RESULT",
+        # The old YAML key is "state_topic_2" (CONF_STATE_TOPIC + "_2")
+        CONF_STATE_TOPIC + "_2": "tele/dual/RESULT2",
+        CONF_MQTT_DELAY: 0,
+        CONF_MIN_TEMP: 16,
+        CONF_MAX_TEMP: 32,
+        CONF_TARGET_TEMP: 26,
+        CONF_PRECISION: PRECISION_WHOLE,
+        CONF_TEMP_STEP: PRECISION_WHOLE,
+        CONF_CELSIUS: "on",
+        CONF_QUIET: "off",
+        CONF_TURBO: "off",
+        CONF_ECONO: "off",
+        CONF_MODEL: "-1",
+        CONF_LIGHT: "off",
+        CONF_FILTER: "off",
+        CONF_CLEAN: "off",
+        CONF_BEEP: "off",
+        CONF_SLEEP: "-1",
+        CONF_KEEP_MODE: False,
+        CONF_IGNORE_OFF_TEMP: False,
+        CONF_MODES_LIST: [HVACMode.OFF, HVACMode.COOL],
+        CONF_FAN_LIST: [HVAC_FAN_MIN],
+        CONF_SWING_LIST: [SWING_OFF],
+        CONF_INITIAL_OPERATION_MODE: HVACMode.OFF,
+        CONF_TOGGLE_LIST: [],
+        CONF_SPECIAL_MODE: "",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "import"}, data=yaml_config
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_STATE_TOPIC_2] == "tele/dual/RESULT2"
+
+
+async def test_reconfigure_updates_entry(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Reconfigure flow updates the config entry data."""
+    from tests.conftest import make_config_entry, setup_integration
+
+    entry = await setup_integration(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Renamed AC",
+            CONF_VENDOR: "DAIKIN",
+            CONF_COMMAND_TOPIC: "cmnd/new/irhvac",
+            CONF_STATE_TOPIC: "tele/new/RESULT",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_NAME] == "Renamed AC"
+    assert entry.data[CONF_VENDOR] == "DAIKIN"
+    assert entry.data[CONF_COMMAND_TOPIC] == "cmnd/new/irhvac"
+
+
+async def test_reconfigure_vendor_required(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Reconfigure flow rejects empty vendor."""
+    from tests.conftest import setup_integration
+
+    entry = await setup_integration(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Test",
+            CONF_VENDOR: "",
+            CONF_COMMAND_TOPIC: "cmnd/test/irhvac",
+            CONF_STATE_TOPIC: "tele/test/RESULT",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"][CONF_VENDOR] == "vendor_required"
+
+
+async def test_float_coercion(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """SelectSelector string values are coerced to float for precision/temp_step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP1_INPUT
+    )
+
+    # Step 2: submit precision and temp_step as strings (as SelectSelector sends them)
+    step2 = dict(STEP2_INPUT)
+    step2[CONF_PRECISION] = str(PRECISION_HALVES)
+    step2[CONF_TEMP_STEP] = str(PRECISION_HALVES)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], step2
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP3_INPUT
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["options"][CONF_PRECISION] == PRECISION_HALVES
+    assert isinstance(result["options"][CONF_PRECISION], float)
+    assert result["options"][CONF_TEMP_STEP] == PRECISION_HALVES
+    assert isinstance(result["options"][CONF_TEMP_STEP], float)

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,234 @@
+"""Tests for the Tasmota IRHVAC options flow (menu-driven)."""
+
+import pytest
+from homeassistant.components.climate.const import HVACMode, SWING_BOTH, SWING_OFF
+from homeassistant.const import PRECISION_HALVES
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.tasmota_irhvac.const import (
+    CONF_CELSIUS,
+    CONF_FAN_LIST,
+    CONF_IGNORE_OFF_TEMP,
+    CONF_KEEP_MODE,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
+    CONF_MODES_LIST,
+    CONF_MQTT_DELAY,
+    CONF_PRECISION,
+    CONF_QUIET,
+    CONF_SPECIAL_MODE,
+    CONF_SWING_LIST,
+    CONF_TARGET_TEMP,
+    CONF_TEMP_SENSOR,
+    CONF_TEMP_STEP,
+    CONF_TOGGLE_LIST,
+    CONF_TURBO,
+    HVAC_FAN_AUTO_MAX,
+    HVAC_FAN_MIN,
+)
+
+from tests.conftest import setup_integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _start_options_flow(hass, entry):
+    """Start the options flow and return the init result."""
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_options_menu_shows(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Init step shows the options menu."""
+    entry = await setup_integration(hass)
+    result = await _start_options_flow(hass, entry)
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "init"
+    assert "mqtt" in result["menu_options"]
+    assert "temperature" in result["menu_options"]
+    assert "modes" in result["menu_options"]
+    assert "defaults" in result["menu_options"]
+    assert "sensors" in result["menu_options"]
+    assert "advanced_options" in result["menu_options"]
+
+
+async def test_mqtt_options(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Changing MQTT delay via options flow updates the entry."""
+    entry = await setup_integration(hass)
+    result = await _start_options_flow(hass, entry)
+
+    # Navigate to MQTT sub-step
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "mqtt"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "mqtt"
+
+    # Submit new MQTT delay
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_MQTT_DELAY: 2.5}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MQTT_DELAY] == 2.5
+
+
+async def test_temperature_options(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Changing temperature settings via options flow updates the entry."""
+    entry = await setup_integration(hass)
+    result = await _start_options_flow(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "temperature"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "temperature"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_MIN_TEMP: 18,
+            CONF_MAX_TEMP: 28,
+            CONF_TARGET_TEMP: 22,
+            CONF_PRECISION: str(PRECISION_HALVES),
+            CONF_TEMP_STEP: str(PRECISION_HALVES),
+            CONF_CELSIUS: "on",
+            CONF_IGNORE_OFF_TEMP: True,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MIN_TEMP] == 18
+    assert entry.options[CONF_MAX_TEMP] == 28
+    assert entry.options[CONF_TARGET_TEMP] == 22
+    # SelectSelector sends strings; coerced to float for storage
+    assert entry.options[CONF_PRECISION] == PRECISION_HALVES
+    assert isinstance(entry.options[CONF_PRECISION], float)
+    assert entry.options[CONF_IGNORE_OFF_TEMP] is True
+
+
+async def test_modes_options(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Changing mode lists via options flow updates the entry."""
+    entry = await setup_integration(hass)
+    result = await _start_options_flow(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "modes"}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    new_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT]
+    new_fans = [HVAC_FAN_AUTO_MAX, HVAC_FAN_MIN]
+    new_swings = [SWING_OFF, SWING_BOTH]
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_MODES_LIST: new_modes,
+            CONF_FAN_LIST: new_fans,
+            CONF_SWING_LIST: new_swings,
+            CONF_KEEP_MODE: True,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MODES_LIST] == new_modes
+    assert entry.options[CONF_FAN_LIST] == new_fans
+    assert entry.options[CONF_SWING_LIST] == new_swings
+    assert entry.options[CONF_KEEP_MODE] is True
+
+
+async def test_defaults_options(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Changing default quiet/turbo/etc via options flow updates the entry."""
+    entry = await setup_integration(hass)
+    result = await _start_options_flow(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "defaults"}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_QUIET: "on", CONF_TURBO: "on"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_QUIET] == "on"
+    assert entry.options[CONF_TURBO] == "on"
+
+
+async def test_sensors_options(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Setting and clearing temperature sensor via options flow."""
+    entry = await setup_integration(hass)
+
+    # Set a sensor
+    result = await _start_options_flow(hass, entry)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "sensors"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "sensors"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_TEMP_SENSOR: "sensor.room_temp"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_TEMP_SENSOR] == "sensor.room_temp"
+
+    # Clear the sensor by not submitting it
+    result = await _start_options_flow(hass, entry)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "sensors"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # When not submitted, the key should be absent from the merged options
+    # (the options flow merges with existing, so the key persists from
+    # the previous save unless the UI explicitly clears it -- this is an
+    # OptionsFlowWithReload characteristic).
+
+
+async def test_advanced_options(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Changing toggle list and special mode via options flow."""
+    entry = await setup_integration(hass)
+    result = await _start_options_flow(hass, entry)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "advanced_options"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "advanced_options"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOGGLE_LIST: ["SwingV", "Quiet"],
+            CONF_SPECIAL_MODE: "cool",
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_TOGGLE_LIST] == ["SwingV", "Quiet"]
+    assert entry.options[CONF_SPECIAL_MODE] == "cool"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,141 @@
+"""Tests for entry setup, unload, YAML import trigger, and service registration."""
+
+import pytest
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.core import HomeAssistant
+
+from custom_components.tasmota_irhvac.const import (
+    CONF_FAN_LIST,
+    CONF_MODES_LIST,
+    DATA_KEY,
+    DOMAIN,
+    HVAC_FAN_MAX,
+)
+
+from tests.conftest import get_climate_entity, make_config_entry, setup_integration
+
+
+async def test_setup_entry_creates_entity(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Setting up a config entry creates a climate entity in hass.data."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+    assert entity is not None
+    assert entity.name == "Test AC"
+
+
+async def test_unload_entry(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Unloading an entry removes the entity from hass.data."""
+    entry = await setup_integration(hass)
+    assert get_climate_entity(hass, entry) is not None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # After unload, the entry should be cleaned from DOMAIN data
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+async def test_yaml_import_triggers_config_flow(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """async_setup_platform triggers an import config flow that creates an entry."""
+    from custom_components.tasmota_irhvac.climate import async_setup_platform
+
+    config = {
+        "name": "YAML Unit",
+        "vendor": "DAIKIN",
+        "command_topic": "cmnd/yaml_test/irhvac",
+        "state_topic": "tele/yaml_test/RESULT",
+        "mqtt_delay": 0,
+        "min_temp": 16,
+        "max_temp": 32,
+        "target_temp": 26,
+        "precision": 1,
+        "temp_step": 1,
+        "celsius_mode": "on",
+        "default_quiet_mode": "off",
+        "default_turbo_mode": "off",
+        "default_econo_mode": "off",
+        "hvac_model": "-1",
+        "default_light_mode": "off",
+        "default_filter_mode": "off",
+        "default_clean_mode": "off",
+        "default_beep_mode": "off",
+        "default_sleep_mode": "-1",
+        "keep_mode_when_off": False,
+        "ignore_off_temp": False,
+        "supported_modes": [HVACMode.OFF, HVACMode.COOL],
+        "supported_fan_speeds": ["min"],
+        "supported_swing_list": ["off"],
+        "initial_operation_mode": HVACMode.OFF,
+        "toggle_list": [],
+        "special_mode": "",
+    }
+
+    # No entries before
+    entries_before = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries_before) == 0
+
+    await async_setup_platform(hass, config, lambda entities: None)
+    await hass.async_block_till_done()
+
+    # The import flow should have completed and created a config entry
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data["vendor"] == "DAIKIN"
+
+
+async def test_services_registered(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """After setup, IRHVAC services (set_econo, set_turbo, etc.) are registered."""
+    await setup_integration(hass)
+
+    expected_services = [
+        "set_econo",
+        "set_turbo",
+        "set_quiet",
+        "set_light",
+        "set_filters",
+        "set_clean",
+        "set_beep",
+        "set_sleep",
+        "set_swingv",
+        "set_swingh",
+    ]
+    for service_name in expected_services:
+        assert hass.services.has_service(DOMAIN, service_name), (
+            f"Service {DOMAIN}.{service_name} not registered"
+        )
+
+
+async def test_entity_state_after_setup(
+    hass: HomeAssistant, enable_custom_integrations, mqtt_mock
+):
+    """Entity has correct initial state: modes, fan, target temp, etc."""
+    entry = await setup_integration(hass)
+    entity = get_climate_entity(hass, entry)
+    assert entity is not None
+
+    # Initial HVAC mode from config
+    assert entity.hvac_mode == HVACMode.OFF
+
+    # Fan modes should be set (default list has max_high/auto_max which map)
+    assert entity.fan_modes is not None
+    assert len(entity.fan_modes) > 0
+
+    # Target temperature from config default
+    assert entity.target_temperature == 26
+
+    # Min/max temp
+    assert entity.min_temp == 16
+    assert entity.max_temp == 32
+
+    # Supported modes from config
+    assert HVACMode.OFF in entity.hvac_modes
+    assert HVACMode.COOL in entity.hvac_modes
+    assert HVACMode.HEAT in entity.hvac_modes


### PR DESCRIPTION
## Summary

I've been working on some larger changes for my fork that has some Fujitsu specific code and more interestingly an in-development PI/RLS approach to a smart heat pump thermostat. I would be happy to contribute either or both of those back if there's any interest, but for now I thought I'd submit this since I moved the integration over to a config flow instead of YAML, which should hopefully make things easier for people getting started.

Replaces YAML-only configuration with a modern UI config flow. Existing YAML configurations are automatically imported on first restart with a persistent notification prompting the user to remove the YAML entry.

- **3-step setup wizard**: device connection (name, vendor, MQTT topics) → climate settings (temp range, modes, fan speeds, swing) → advanced settings (default modes, sensors, toggles)
- **Options flow** with 6 categories: MQTT, Temperature, Modes, Defaults, Sensors, Advanced
- **Reconfigure flow** for updating connection settings post-setup
- **YAML import** with deprecation warning and persistent notification
- **Duplicate entry prevention** via unique_id (vendor + command_topic)

## What changed

| File | Change |
|------|--------|
| `config_flow.py` | New — config flow with setup wizard, options, reconfigure, and YAML import |
| `strings.json` / `translations/en.json` | New — UI strings for all config flow steps and options |
| `__init__.py` | Replaced stub with `async_setup_entry` / `async_unload_entry` and service registration |
| `climate.py` | Added `async_setup_entry`, converted `async_setup_platform` to import-only shim, formalized `CONF_STATE_TOPIC_2` constant |
| `const.py` | Added `CONF_STATE_TOPIC_2`, `PLATFORMS` |
| `manifest.json` | Added `config_flow: true`, bumped `homeassistant` minimum to `2026.1.0` (requires `OptionsFlowWithReload`), removed unnecessary `sensor` dependency |

### Notes on specific changes

**`state_topic_2`**: The existing codebase supports dual MQTT topics (`tele` + `stat`) via the string concatenation `CONF_STATE_TOPIC + "_2"`. This PR formalizes it as a proper `CONF_STATE_TOPIC_2` constant and exposes it in the config flow UI. The YAML import handles migration from the old key format. No behavioral change.

**`sensor` dependency removed**: The original manifest listed `sensor` as a dependency, but the integration only *reads from* external sensor entities via event listeners — it doesn't depend on the sensor platform being loaded. Removed to match actual dependencies.

**`homeassistant` minimum bumped to `2026.1.0`**: Required for `OptionsFlowWithReload`, which allows options changes to take effect without manual restart. This is a breaking change for users on older HA versions.

**Precision / temp_step handling**: `SelectSelector` returns string values, which are coerced to floats when saving to the config entry. When populating the options flow form, stored floats are converted back to strings for SelectSelector compatibility.

**Service registration**: Moved from `climate.py` to `__init__.py` to follow config entry lifecycle conventions. Registration is idempotent.

## Tests

32 tests added covering config flow, options flow, MQTT setup, and entity lifecycle:

| Test file | Tests | Coverage |
|-----------|-------|---------|
| `test_config_flow.py` | 15 | Config flow steps, YAML import, duplicate prevention |
| `test_options_flow.py` | 8 | All 6 option categories + reconfigure |
| `test_climate_mqtt.py` | 5 | MQTT subscribe/publish, state message parsing |
| `test_setup.py` | 4 | Entry setup, unload, service registration |

`config_flow.py` at 99% coverage.

## Known issues / future cleanup

The fan speed option list contains duplicate string values under different constant names:
- `HVAC_FAN_MEDIUM` and `FAN_MEDIUM` both resolve to `"medium"`
- `HVAC_FAN_AUTO` and `FAN_AUTO` both resolve to `"auto"`

These are preserved from the existing `DEFAULT_FAN_LIST` in `const.py` to avoid breaking YAML imports that may reference either form. A future cleanup could consolidate these, but it should be done carefully across the whole codebase to ensure no vendor-specific code depends on the distinction.
